### PR TITLE
fix: use CSRF token from response body as fallback when cookie is unreadable

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -27,8 +27,8 @@ function getCookie(name) {
 async function ensureCsrfCookie() {
   const token = getCookie("csrftoken");
   if (token) return token;
-  await api.get("/auth/csrf/");
-  return getCookie("csrftoken");
+  const { data } = await api.get("/auth/csrf/");
+  return getCookie("csrftoken") || data.csrfToken;
 }
 
 api.interceptors.request.use(async (config) => {


### PR DESCRIPTION
## Summary
- `ensureCsrfCookie()` now captures the `/auth/csrf/` response and falls back to `data.csrfToken` if the `csrftoken` cookie isn't readable
- Fixes "CSRF token missing" errors when creating posts in cross-origin setups where the cookie may not be accessible via `document.cookie`
- No behavior change when the cookie is already present

## Test plan
- [ ] Log in and create a new post — should succeed without CSRF errors
- [ ] Verify other mutating actions (comments, votes, logout) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CSRF authentication token retrieval with improved fallback handling for increased security robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->