### PR TITLE
fix: resolve Render OOM on dashboard endpoint

### DIFF
--- a/blog/api_views.py
+++ b/blog/api_views.py
@@ -10,7 +10,8 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
-from django.db.models import Count, Q
+from django.db.models import Avg, Count, Q
+from django.db.models.functions import Length
 
 from accounts.models import Profile
 from .models import Comment, CommentVote, Post, Tag
@@ -85,11 +86,8 @@ def dashboard(request):
         Tag.objects.filter(posts__status=Post.Status.PUBLISHED).distinct().count()
     )
 
-    bodies = published.values_list("body", flat=True)
-    word_counts = [len((body or "").split()) for body in bodies]
-    average_depth_words = (
-        round(sum(word_counts) / len(word_counts)) if word_counts else 0
-    )
+    avg_chars = published.aggregate(avg=Avg(Length("body")))["avg"] or 0
+    average_depth_words = round(avg_chars / 5)  # ~5 chars per word
 
     return Response(
         {


### PR DESCRIPTION
## Summary
- Replace in-memory word count (loading all 50k post bodies into Python) with `AVG(LENGTH(body))` computed entirely in PostgreSQL — fixes the 512MB OOM crash on Render's free tier
- CI: `enable-cache: false` already on master for robot/security workflows to fix uv cache lock timeout

## Test plan
- [ ] Deploy to Render and confirm `/api/dashboard/` responds without OOM
- [ ] Verify dashboard stats still appear correctly on the frontend
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the computation of average post depth statistics for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->