### PR TITLE
fix(frontend): use URL search param to open new-post composer

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -97,7 +97,7 @@ export default function Navbar() {
                       return;
                     }
                     e.preventDefault();
-                    navigate("/posts?create=1");
+                    navigate("/posts?create=1", { replace: true });
                   }}
                 >
                   + New Post

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -89,8 +89,7 @@ export default function Navbar() {
                   Logout
                 </button>
                 <Link
-                  to="/posts"
-                  state={{ openCreate: true }}
+                  to="/posts?create=1"
                   className="nb-btn-head cta"
                   onClick={(e) => {
                     if (location.pathname !== "/posts") return;
@@ -98,7 +97,7 @@ export default function Navbar() {
                       return;
                     }
                     e.preventDefault();
-                    navigate("/posts", { state: { openCreate: true }, replace: true });
+                    navigate("/posts?create=1");
                   }}
                 >
                   + New Post

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation, useSearchParams } from "react-router-dom";
 import { vi } from "vitest";
 import { fetchDashboard } from "../api/client";
 
@@ -16,8 +16,9 @@ vi.mock("../context/AuthContext", () => ({
 import Navbar from "./Navbar";
 
 function LocationEcho() {
-  const { pathname, state } = useLocation();
-  const open = Boolean(state?.openCreate);
+  const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
+  const open = searchParams.get("create") === "1";
   return (
     <div>
       <div data-testid="echo-path">{pathname}</div>
@@ -54,6 +55,16 @@ describe("Navbar", () => {
     await waitFor(() =>
       expect(screen.getByRole("link", { name: "+ New Post" })).toBeInTheDocument(),
     );
+  });
+
+  it("the + New Post link href includes ?create=1", async () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole("link", { name: "+ New Post" });
+    expect(link).toHaveAttribute("href", "/posts?create=1");
   });
 
   it("does not show + New Post when logged out", async () => {

--- a/frontend/src/pages/PostList.jsx
+++ b/frontend/src/pages/PostList.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { createPost, deletePost, fetchPosts, fetchTags } from "../api/client";
 import StatusBadge from "../components/StatusBadge";
 import { useAuth } from "../context/AuthContext";
@@ -57,7 +57,7 @@ function MarkdownEditor({ value, onChange, disabled = false }) {
 export default function PostList() {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [items, setItems] = useState(null);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -102,14 +102,10 @@ export default function PostList() {
   }, []);
 
   useEffect(() => {
-    if (!location.state?.openCreate) return;
+    if (searchParams.get("create") !== "1") return;
     setShowCreate(true);
-    const { openCreate: _, ...restState } = location.state;
-    navigate(
-      { pathname: location.pathname, search: location.search, hash: location.hash },
-      { replace: true, state: restState },
-    );
-  }, [location.pathname, location.search, location.state, navigate]);
+    setSearchParams({}, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   const loadMore = () => {
     const next = page + 1;

--- a/frontend/src/pages/PostList.test.jsx
+++ b/frontend/src/pages/PostList.test.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useSearchParams } from "react-router-dom";
 import { vi } from "vitest";
 import { fetchPosts, fetchTags } from "../api/client";
 
@@ -28,10 +29,9 @@ const SAMPLE_POST = {
   comment_count: 0,
 };
 
-function RouterStateEmpty() {
-  const { state } = useLocation();
-  const empty = !state || Object.keys(state).length === 0;
-  return <span data-testid="router-state-empty">{empty ? "yes" : "no"}</span>;
+function CreateParamEcho() {
+  const [searchParams] = useSearchParams();
+  return <span data-testid="create-param">{searchParams.get("create") ?? "none"}</span>;
 }
 
 afterEach(() => {
@@ -65,18 +65,16 @@ describe("PostList", () => {
     expect(screen.queryByPlaceholderText(/compelling title/i)).toBeNull();
   });
 
-  it("opens the create composer and clears openCreate from history when requested via location state", async () => {
+  it("opens the create composer and clears the create param from the URL when requested via search param", async () => {
     render(
-      <MemoryRouter
-        initialEntries={[{ pathname: "/posts", state: { openCreate: true } }]}
-      >
+      <MemoryRouter initialEntries={["/posts?create=1"]}>
         <Routes>
           <Route
             path="/posts"
             element={
               <>
                 <PostList />
-                <RouterStateEmpty />
+                <CreateParamEcho />
               </>
             }
           />
@@ -87,6 +85,43 @@ describe("PostList", () => {
     await waitFor(() =>
       expect(screen.getByPlaceholderText(/compelling title/i)).toBeInTheDocument(),
     );
-    await waitFor(() => expect(screen.getByTestId("router-state-empty")).toHaveTextContent("yes"));
+    await waitFor(() => expect(screen.getByTestId("create-param")).toHaveTextContent("none"));
+  });
+
+  it("closes the composer when the Cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/posts?create=1"]}>
+        <Routes>
+          <Route path="/posts" element={<PostList />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/compelling title/i)).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByPlaceholderText(/compelling title/i)).toBeNull();
+  });
+
+  it("opens the composer via the inline toggle button without a URL param", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/posts"]}>
+        <Routes>
+          <Route path="/posts" element={<PostList />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.queryByText("Hello")).toBeInTheDocument());
+    expect(screen.queryByPlaceholderText(/compelling title/i)).toBeNull();
+
+    await user.click(screen.getAllByRole("button", { name: "+ New Post" })[0]);
+
+    expect(screen.getByPlaceholderText(/compelling title/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Replaces router `location.state` with `?create=1` search param to trigger the new-post form in `PostList`
- Root cause: in React 19's concurrent renderer, the `navigate()` call inside the `useEffect` (clearing the state) could be scheduled at higher priority than `setShowCreate(true)`, leaving the form permanently hidden in the production build
- `setSearchParams` is atomic with component state — no race, no extra navigate call needed

## Test plan
- [x] 38 frontend tests pass (`npm test -- --run`)
- [x] 205 backend tests pass (`pytest`)
- [x] New tests: Cancel closes form, inline toggle opens form, Navbar link href confirmed
- [ ] Deploy to Vercel and verify: log in → click "+ New Post" → form appears on `/posts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * "New Post" now uses a URL query parameter to open the create form, improving bookmarkability and shareability; the parameter is cleared after use.

* **Behavior**
  * Create-composer opens via the query param or inline toggle and closes correctly when canceled.

* **Tests**
  * Updated tests to validate query-parameter behavior and composer open/close interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->