### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,32 @@ All endpoints are rate-limited. Default page size: **10**.
 - Review `tests/security/SECURITY_CHECKLIST.md` before deploying.
 - CSRF token available at `GET /api/auth/csrf/` — React reads it from cookies.
 - Auth is session-based (not JWT), managed by Django sessions.
+
+---
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Port | How to start |
+|---|---|---|
+| PostgreSQL 16 | 5432 | `sudo pg_ctlcluster 16 main start` (installed via `apt`) |
+| Django backend | 8000 | `uv run python manage.py runserver 0.0.0.0:8000` (from repo root) |
+| React frontend | 5173 | `npm run dev -- --host 0.0.0.0 --port 5173` (from `frontend/`) |
+
+### Environment files
+
+`.env.local` and `.env.testing` are gitignored and must be created manually. Reference `.env.example` for the full variable list. Key values for local dev:
+- `SECRET_KEY` — any non-empty string (e.g. `dev-secret-key-for-local-development`)
+- `DB_*` — `claude_rest_api` / `claude_rest_api` / `claude_rest_api` / `localhost` / `5432`
+- `ACCOUNT_EMAIL_VERIFICATION=none` and `FEATURE_EMAIL_VERIFICATION_ROLLOUT=false` — disables email verification so registration works without a mail server
+- `.env.testing` should also set `PASSWORD_HASHERS=django.contrib.auth.hashers.MD5PasswordHasher` for fast tests
+
+### Gotchas
+
+- The register API field is `password` (not `password1`/`password2`). Login accepts `email` (not `username`).
+- `pytest` uses SQLite in-memory by default (`DJANGO_ENV=testing`), so PostgreSQL is **not** needed for unit tests. Set `TEST_USE_POSTGRES=true` to use Postgres in tests.
+- Always run `uv run python manage.py migrate` after pulling new code — migrations may have been added.
+- `uv run` prefix is needed to use the virtualenv managed by `uv` (or activate `.venv` manually).
+- Frontend `npm ci` may warn about deprecated packages — these are safe to ignore.
+- Pre-commit hooks block direct commits to `main` and `production` branches.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` to help future Cloud Agents set up and run the development environment without repeating discovery steps.

### What's included

- **Services overview table** — PostgreSQL 16, Django backend, React frontend with ports and startup commands
- **Environment file setup** — how to create `.env.local` and `.env.testing` from `.env.example`, with key variable values
- **Gotchas** — non-obvious caveats discovered during setup:
  - Register API uses `password` field (not `password1`/`password2`)
  - Login accepts `email` (not `username`)
  - `pytest` uses SQLite in-memory by default (no Postgres needed for unit tests)
  - `uv run` prefix is needed for the managed virtualenv
  - Pre-commit hooks block direct commits to `main`/`production`

### Verification

All services were started and verified working:

[demo_blog_platform_working.mp4](https://cursor.com/agents/bc-86720896-eb39-41dd-8e98-e1b9b63328ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_blog_platform_working.mp4)

Full-stack blog platform running: user registration, login, post creation, and dashboard all working end-to-end.

[Dashboard showing logged-in state with stats](https://cursor.com/agents/bc-86720896-eb39-41dd-8e98-e1b9b63328ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_logged_in.webp)
[Blog post detail page](https://cursor.com/agents/bc-86720896-eb39-41dd-8e98-e1b9b63328ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_detail.webp)

| Check | Result |
|---|---|
| `ruff check .` | All checks passed |
| `eslint .` | 0 errors, 1 pre-existing warning |
| `pytest` (211 tests) | All passed |
| `vitest run` (39 tests) | All passed |
| Backend dev server | Running on :8000 |
| Frontend dev server | Running on :5173 |
| API hello-world (register + create post) | Working |

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86720896-eb39-41dd-8e98-e1b9b63328ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86720896-eb39-41dd-8e98-e1b9b63328ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

