### PR TITLE
fix(api): restore OPTIONS compatibility on migrated read routes

### DIFF
--- a/blog/api_urls.py
+++ b/blog/api_urls.py
@@ -24,8 +24,14 @@ urlpatterns = [
     path("auth/", public_auth_api.urls),
     path("_ninja/auth/", preview_auth_api.urls),
     path("_ninja/read/", preview_read_api.urls),
-    path("dashboard/", public_read_callbacks["dashboard"]),
-    path("comments/", public_read_callbacks["comment_list"]),
+    path(
+        "dashboard/",
+        _get_or_drf(public_read_callbacks["dashboard"], api_views.dashboard),
+    ),
+    path(
+        "comments/",
+        _get_or_drf(public_read_callbacks["comment_list"], api_views.comment_list),
+    ),
     path("posts/<slug:slug>/comments/", api_views.comment_create),
     path(
         "posts/", _get_or_drf(public_read_callbacks["post_list"], api_views.post_list)
@@ -39,9 +45,15 @@ urlpatterns = [
         "tags/<slug:slug>/",
         _get_or_drf(public_read_callbacks["tag_detail"], api_views.tag_detail),
     ),
-    path("users/", public_read_callbacks["user_list"]),
-    path("users/<str:username>/comments/", public_read_callbacks["user_comments"]),
-    path("users/<str:username>/", public_read_callbacks["user_detail"]),
+    path("users/", _get_or_drf(public_read_callbacks["user_list"], api_views.user_list)),
+    path(
+        "users/<str:username>/comments/",
+        _get_or_drf(public_read_callbacks["user_comments"], api_views.user_comments),
+    ),
+    path(
+        "users/<str:username>/",
+        _get_or_drf(public_read_callbacks["user_detail"], api_views.user_detail),
+    ),
     path("auth/login/", api_views.login_view),
     path("auth/register/", api_views.register_view),
     path("auth/resend-verification/", api_views.resend_verification_view),

--- a/tests/unit/test_read_route_method_compat.py
+++ b/tests/unit/test_read_route_method_compat.py
@@ -1,0 +1,34 @@
+"""Regression tests for public read-route HTTP method compatibility."""
+
+import pytest
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("path", ["/api/dashboard/", "/api/comments/", "/api/users/"])
+def test_public_read_list_routes_keep_options(api_client, path):
+    """Read list routes still answer OPTIONS after the Ninja GET cutover."""
+    resp = api_client.options(path)
+    assert resp.status_code == 200
+    allow = resp.headers.get("Allow", "")
+    assert "GET" in allow
+    assert "OPTIONS" in allow
+
+
+@pytest.mark.django_db
+def test_public_user_detail_route_keeps_options(api_client, user):
+    """User detail route supports OPTIONS metadata requests."""
+    resp = api_client.options(f"/api/users/{user.username}/")
+    assert resp.status_code == 200
+    allow = resp.headers.get("Allow", "")
+    assert "GET" in allow
+    assert "OPTIONS" in allow
+
+
+@pytest.mark.django_db
+def test_public_user_comments_route_keeps_options(api_client, user):
+    """User comments route supports OPTIONS metadata requests."""
+    resp = api_client.options(f"/api/users/{user.username}/comments/")
+    assert resp.status_code == 200
+    allow = resp.headers.get("Allow", "")
+    assert "GET" in allow
+    assert "OPTIONS" in allow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix a regression in recently migrated read routes where several public endpoints (`/api/dashboard/`, `/api/comments/`, `/api/users/`, `/api/users/<username>/`, `/api/users/<username>/comments/`) returned `405 Method Not Allowed` for `OPTIONS`
- restore compatibility by routing non-GET methods for those paths through the existing DRF handlers while still using Ninja handlers for `GET`
- add focused regression tests to lock in `OPTIONS` support on affected routes

## Reproduction and validation
- Reproduced on current `master` before the fix (captured below)
- Validated after fix on this branch (captured below)
- Ran targeted pytest coverage for compatibility + user read flows

### Repro artifacts
[repro_options_before_fix.log](https://cursor.com/agents/bc-efc08164-cac4-4caa-ae2d-cfbbf362203c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro_options_before_fix.log)

[repro_options_after_fix.log](https://cursor.com/agents/bc-efc08164-cac4-4caa-ae2d-cfbbf362203c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro_options_after_fix.log)

## Tests run
- `uv run pytest tests/unit/test_read_route_method_compat.py tests/unit/test_views_users.py tests/unit/test_ninja_read_preview.py::TestNinjaReadPreview::test_user_routes_are_available`
- `uv run pytest tests/unit/test_read_route_method_compat.py tests/unit/test_ninja_read_preview.py::TestNinjaReadPreview::test_user_routes_are_available tests/unit/test_views_posts.py::TestPostList::test_create_post_authenticated_returns_201`

## Risk
- Low: routing-only change on five read-only public paths, with fallback behavior matching pre-migration DRF handling for non-GET methods.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efc08164-cac4-4caa-ae2d-cfbbf362203c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efc08164-cac4-4caa-ae2d-cfbbf362203c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

