### PR TITLE
feat(frontend): integrate React frontend with Ninja API email verification

### DIFF
--- a/blog/api/write/router.py
+++ b/blog/api/write/router.py
@@ -119,7 +119,10 @@ def login(request: HttpRequest):
     ):
         if not has_verified_email(user):
             return json_compat_response(
-                {"detail": "Email address is not verified. Please check your inbox."},
+                {
+                    "detail": "Email address is not verified. Please check your inbox.",
+                    "code": "email_not_verified",
+                },
                 status=403,
             )
 
@@ -182,7 +185,8 @@ def register(request: HttpRequest):
             )
         return json_compat_response(
             {
-                "detail": "Registration successful. Please check your email to verify your account."
+                "detail": "Registration successful. Please check your email to verify your account.",
+                "code": "verification_pending",
             },
             status=201,
         )
@@ -194,13 +198,31 @@ def register(request: HttpRequest):
 @router.post("/auth/resend-verification/", throttle=WRITE_RESEND_VERIFICATION_THROTTLES)
 def resend_verification(request: HttpRequest):
     attach_forced_user(request)
-    if not request.user.is_authenticated:
-        return json_compat_response({"detail": "Authentication required."}, status=401)
 
-    user = request.user
+    user = None
+    if request.user.is_authenticated:
+        user = request.user
+    else:
+        data, error = _request_data_or_error(request)
+        if error is not None:
+            return error
+        email = data.get("email", "")
+        if isinstance(email, str):
+            email = email.strip().lower()
+        if email:
+            try:
+                user = User.objects.get(email=email)
+            except (User.DoesNotExist, User.MultipleObjectsReturned):
+                pass
+
+    if user is None:
+        return json_compat_response(
+            {"detail": "Verification email sent. Please check your inbox."}
+        )
+
     if has_verified_email(user):
         return json_compat_response(
-            {"detail": "Email is already verified."}, status=400
+            {"detail": "Verification email sent. Please check your inbox."}
         )
 
     setup_user_email(request, user, [])

--- a/blog/api/write/router.py
+++ b/blog/api/write/router.py
@@ -198,17 +198,23 @@ def register(request: HttpRequest):
 @router.post("/auth/resend-verification/", throttle=WRITE_RESEND_VERIFICATION_THROTTLES)
 def resend_verification(request: HttpRequest):
     attach_forced_user(request)
+    success_response = json_compat_response(
+        {"detail": "Verification email sent. Please check your inbox."}
+    )
+    is_anonymous_request = not request.user.is_authenticated
 
     user = None
-    if request.user.is_authenticated:
+    if not is_anonymous_request:
         user = request.user
     else:
         data, error = _request_data_or_error(request)
         if error is not None:
             return error
         email = data.get("email", "")
-        if isinstance(email, str):
-            email = email.strip().lower()
+        if not isinstance(email, str):
+            # Keep responses uniform for anonymous callers and avoid ORM type errors.
+            return success_response
+        email = email.strip().lower()
         if email:
             try:
                 user = User.objects.get(email=email)
@@ -216,31 +222,38 @@ def resend_verification(request: HttpRequest):
                 pass
 
     if user is None:
-        return json_compat_response(
-            {"detail": "Verification email sent. Please check your inbox."}
-        )
+        return success_response
 
     if has_verified_email(user):
-        return json_compat_response(
-            {"detail": "Verification email sent. Please check your inbox."}
-        )
+        return success_response
 
     setup_user_email(request, user, [])
-    try:
-        send_verification_email_for_user(request, user)
-    except (smtplib.SMTPException, BadHeaderError, socket.timeout, TimeoutError):
-        api_views.security_log.exception(
-            "Failed to resend verification email for user_id=%s",
-            user.pk,
-        )
-        return json_compat_response(
-            {"detail": "Failed to send verification email. Please try again later."},
-            status=500,
-        )
+    if is_anonymous_request:
+        try:
+            send_verification_email_for_user(request, user)
+        except Exception:
+            # Preserve anti-enumeration behavior during mail transport outages.
+            api_views.security_log.exception(
+                "Failed to resend verification email for user_id=%s",
+                user.pk,
+            )
+            return success_response
+    else:
+        try:
+            send_verification_email_for_user(request, user)
+        except (smtplib.SMTPException, BadHeaderError, socket.timeout, TimeoutError):
+            api_views.security_log.exception(
+                "Failed to resend verification email for user_id=%s",
+                user.pk,
+            )
+            return json_compat_response(
+                {
+                    "detail": "Failed to send verification email. Please try again later."
+                },
+                status=500,
+            )
 
-    return json_compat_response(
-        {"detail": "Verification email sent. Please check your inbox."}
-    )
+    return success_response
 
 
 @router.patch("/auth/profile/")

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -71,6 +71,8 @@ export const updateComment = (commentId, body) =>
 export const deleteComment = (commentId) =>
   api.delete(`/comments/${commentId}/`).then((r) => r.data);
 
+export const resendVerification = (email) => api.post("/auth/resend-verification/", { email }).then((r) => r.data);
+
 export const fetchCsrf = () => api.get("/auth/csrf/").then((r) => r.data);
 
 export default api;

--- a/frontend/src/hooks/useResendVerification.js
+++ b/frontend/src/hooks/useResendVerification.js
@@ -1,0 +1,34 @@
+import { useCallback, useRef, useState } from "react";
+import { resendVerification } from "../api/client";
+
+export default function useResendVerification() {
+  const [resendMessage, setResendMessage] = useState(null);
+  const [resendIsError, setResendIsError] = useState(false);
+  const [resending, setResending] = useState(false);
+  const inflight = useRef(false);
+
+  const handleResend = useCallback(async (email) => {
+    if (inflight.current) return;
+    inflight.current = true;
+    setResending(true);
+    setResendMessage(null);
+    try {
+      const result = await resendVerification(email);
+      setResendMessage(result?.detail ?? "Verification email sent. Please check your inbox.");
+      setResendIsError(false);
+    } catch (err) {
+      setResendMessage(err.response?.data?.detail ?? "Failed to resend verification email.");
+      setResendIsError(true);
+    } finally {
+      setResending(false);
+      inflight.current = false;
+    }
+  }, []);
+
+  const clearResend = useCallback(() => {
+    setResendMessage(null);
+    setResendIsError(false);
+  }, []);
+
+  return { resendMessage, resendIsError, resending, handleResend, clearResend };
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,6 +11,7 @@ export default function Login() {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [needsVerification, setNeedsVerification] = useState(false);
+  const [pendingVerificationEmail, setPendingVerificationEmail] = useState("");
   const { resendMessage, resendIsError, resending, handleResend, clearResend } =
     useResendVerification();
 
@@ -18,17 +19,21 @@ export default function Login() {
 
   const submit = async (e) => {
     e.preventDefault();
+    const submittedEmail = form.email;
     setError(null);
     setNeedsVerification(false);
+    setPendingVerificationEmail("");
     clearResend();
     setLoading(true);
     try {
-      const user = await loginUser(form.email, form.password);
+      const user = await loginUser(submittedEmail, form.password);
       setUser(user);
       navigate("/dashboard");
     } catch (err) {
+      const needsEmailVerification = err.response?.data?.code === "email_not_verified";
       const detail = err.response?.data?.detail ?? "Login failed.";
-      setNeedsVerification(err.response?.data?.code === "email_not_verified");
+      setNeedsVerification(needsEmailVerification);
+      setPendingVerificationEmail(needsEmailVerification ? submittedEmail : "");
       setError(detail);
     } finally {
       setLoading(false);
@@ -49,8 +54,8 @@ export default function Login() {
                     type="button"
                     className="nb-btn nb-btn-secondary mt-3"
                     style={{ display: "block", width: "100%", fontSize: "12px" }}
-                    onClick={() => handleResend(form.email)}
-                    disabled={resending}
+                    onClick={() => handleResend(pendingVerificationEmail)}
+                    disabled={resending || !pendingVerificationEmail}
                   >
                     {resending ? (
                       <span className="spinner-border spinner-border-sm me-2" />

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { GOOGLE_LOGIN_URL, loginUser } from "../api/client";
 import { useAuth } from "../context/AuthContext";
+import useResendVerification from "../hooks/useResendVerification";
 
 export default function Login() {
   const { setUser } = useAuth();
@@ -9,19 +10,26 @@ export default function Login() {
   const [form, setForm] = useState({ email: "", password: "" });
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [needsVerification, setNeedsVerification] = useState(false);
+  const { resendMessage, resendIsError, resending, handleResend, clearResend } =
+    useResendVerification();
 
   const handle = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
   const submit = async (e) => {
     e.preventDefault();
     setError(null);
+    setNeedsVerification(false);
+    clearResend();
     setLoading(true);
     try {
       const user = await loginUser(form.email, form.password);
       setUser(user);
       navigate("/dashboard");
     } catch (err) {
-      setError(err.response?.data?.detail ?? "Login failed.");
+      const detail = err.response?.data?.detail ?? "Login failed.";
+      setNeedsVerification(err.response?.data?.code === "email_not_verified");
+      setError(detail);
     } finally {
       setLoading(false);
     }
@@ -33,7 +41,30 @@ export default function Login() {
         <div className="nb-auth-box">
           <div className="nb-auth-header">Login</div>
           <div className="nb-auth-body">
-            {error && <div className="alert alert-danger mb-4">{error}</div>}
+            {error && (
+              <div className="alert alert-danger mb-4">
+                {error}
+                {needsVerification && (
+                  <button
+                    type="button"
+                    className="nb-btn nb-btn-secondary mt-3"
+                    style={{ display: "block", width: "100%", fontSize: "12px" }}
+                    onClick={() => handleResend(form.email)}
+                    disabled={resending}
+                  >
+                    {resending ? (
+                      <span className="spinner-border spinner-border-sm me-2" />
+                    ) : null}
+                    Resend verification email
+                  </button>
+                )}
+              </div>
+            )}
+            {resendMessage && (
+              <div className={`alert mb-4 ${resendIsError ? "alert-danger" : "alert-success"}`}>
+                {resendMessage}
+              </div>
+            )}
             <form onSubmit={submit}>
               <div className="nb-field">
                 <label htmlFor="login-email">Email</label>

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -209,6 +209,36 @@ describe('Login page', () => {
     expect(resendVerification).toHaveBeenCalledWith('unverified@example.com');
   });
 
+  it('resends verification for the captured failed email even after input changes', async () => {
+    const err = {
+      response: { status: 403, data: { detail: 'Email address is not verified.', code: 'email_not_verified' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(err);
+    vi.mocked(resendVerification).mockResolvedValue({
+      detail: 'Verification email sent. Please check your inbox.',
+    });
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'unverified@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+
+    await user.clear(screen.getByLabelText(/email/i));
+    await user.type(screen.getByLabelText(/email/i), 'changed@example.com');
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Verification email sent. Please check your inbox.')).toBeInTheDocument()
+    );
+    expect(resendVerification).toHaveBeenCalledWith('unverified@example.com');
+  });
+
   it('shows resend failure in a danger alert', async () => {
     const loginErr = {
       response: { status: 403, data: { detail: 'Not verified.', code: 'email_not_verified' } },

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { GOOGLE_LOGIN_URL, loginUser } from '../api/client';
+import { resendVerification } from '../api/client';
 
 vi.mock('../api/client', () => import('../test/mocks/client.js'));
 vi.mock('react-router-dom', () => ({
@@ -136,6 +137,174 @@ describe('Login page', () => {
     await waitFor(() => expect(screen.getByText('Invalid credentials.')).toBeInTheDocument());
 
     await user.click(screen.getByRole('button', { name: /login/i }));
-    await waitFor(() => expect(screen.queryByText('Invalid credentials.')).toBeNull());
+    await waitFor(() => expect(screen.queryByText('Invalid credentials.')).not.toBeInTheDocument());
+  });
+
+  // ── Email verification flow ───────────────────────────────────────────
+
+  it('shows a resend button when login fails with code email_not_verified', async () => {
+    const err = {
+      response: { status: 403, data: { detail: 'Email address is not verified.', code: 'email_not_verified' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(err);
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'unverified@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Email address is not verified.')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument();
+    });
+  });
+
+  it('does not show resend button for non-verification 403 errors', async () => {
+    const err = {
+      response: { status: 403, data: { detail: 'Permission denied.' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(err);
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'a@a.com');
+    await user.type(screen.getByLabelText(/password/i), 'pass');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Permission denied.')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /resend verification email/i })).not.toBeInTheDocument();
+  });
+
+  it('calls resendVerification with the entered email and shows success in a success alert', async () => {
+    const err = {
+      response: { status: 403, data: { detail: 'Email address is not verified.', code: 'email_not_verified' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(err);
+    vi.mocked(resendVerification).mockResolvedValue({
+      detail: 'Verification email sent. Please check your inbox.',
+    });
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'unverified@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() => {
+      const alert = screen.getByText('Verification email sent. Please check your inbox.');
+      expect(alert).toBeInTheDocument();
+      expect(alert.closest('.alert')).toHaveClass('alert-success');
+    });
+    expect(resendVerification).toHaveBeenCalledWith('unverified@example.com');
+  });
+
+  it('shows resend failure in a danger alert', async () => {
+    const loginErr = {
+      response: { status: 403, data: { detail: 'Not verified.', code: 'email_not_verified' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(loginErr);
+    vi.mocked(resendVerification).mockRejectedValue({
+      response: { data: { detail: 'Too many requests.' } },
+    });
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'unverified@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() => {
+      const alert = screen.getByText('Too many requests.');
+      expect(alert).toBeInTheDocument();
+      expect(alert.closest('.alert')).toHaveClass('alert-danger');
+    });
+  });
+
+  it('falls back to generic message when resend fails without a detail field', async () => {
+    const loginErr = {
+      response: { status: 403, data: { detail: 'Not verified.', code: 'email_not_verified' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(loginErr);
+    vi.mocked(resendVerification).mockRejectedValue(new Error('network'));
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'unverified@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Failed to resend verification email.')).toBeInTheDocument()
+    );
+  });
+
+  it('disables the resend button and shows spinner while resending', async () => {
+    const loginErr = {
+      response: { status: 403, data: { detail: 'Not verified.', code: 'email_not_verified' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(loginErr);
+    vi.mocked(resendVerification).mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'unverified@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    expect(screen.getByRole('button', { name: /resend verification email/i })).toBeDisabled();
+    expect(document.querySelectorAll('.spinner-border').length).toBeGreaterThan(0);
+  });
+
+  it('uses fallback success message when resend response has no detail', async () => {
+    const loginErr = {
+      response: { status: 403, data: { detail: 'Not verified.', code: 'email_not_verified' } },
+    };
+    vi.mocked(loginUser).mockRejectedValue(loginErr);
+    vi.mocked(resendVerification).mockResolvedValue({});
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.type(screen.getByLabelText(/email/i), 'unverified@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Verification email sent. Please check your inbox.')).toBeInTheDocument()
+    );
   });
 });

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { GOOGLE_LOGIN_URL, registerUser } from "../api/client";
 import { useAuth } from "../context/AuthContext";
+import useResendVerification from "../hooks/useResendVerification";
 
 export default function Register() {
   const { setUser } = useAuth();
@@ -10,6 +11,10 @@ export default function Register() {
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [needsVerification, setNeedsVerification] = useState(false);
+  const [pendingEmail, setPendingEmail] = useState("");
+  const { resendMessage, resendIsError, resending, handleResend, clearResend } =
+    useResendVerification();
 
   const handle = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
@@ -17,17 +22,25 @@ export default function Register() {
     e.preventDefault();
     setError(null);
     setSuccess(null);
+    setNeedsVerification(false);
+    setPendingEmail("");
+    clearResend();
     setLoading(true);
     try {
       const result = await registerUser(form.email, form.username, form.password);
-      if (result?.username) {
-        setUser(result);
-        navigate("/dashboard");
-      } else {
+      if (result?.code === "verification_pending") {
         setSuccess(
           result?.detail ??
             "Registration successful. Please check your email to verify your account."
         );
+        setNeedsVerification(true);
+        setPendingEmail(form.email);
+        setForm({ email: "", username: "", password: "" });
+      } else if (result?.username) {
+        setUser(result);
+        navigate("/dashboard");
+      } else {
+        setSuccess(result?.detail ?? "Registration successful.");
         setForm({ email: "", username: "", password: "" });
       }
     } catch (err) {
@@ -44,7 +57,30 @@ export default function Register() {
           <div className="nb-auth-header">Create Account</div>
           <div className="nb-auth-body">
             {error && <div className="alert alert-danger mb-4">{error}</div>}
-            {success && <div className="alert alert-success mb-4">{success}</div>}
+            {success && (
+              <div className="alert alert-success mb-4">
+                {success}
+                {needsVerification && (
+                  <button
+                    type="button"
+                    className="nb-btn nb-btn-secondary mt-3"
+                    style={{ display: "block", width: "100%", fontSize: "12px" }}
+                    onClick={() => handleResend(pendingEmail)}
+                    disabled={resending}
+                  >
+                    {resending ? (
+                      <span className="spinner-border spinner-border-sm me-2" />
+                    ) : null}
+                    Resend verification email
+                  </button>
+                )}
+              </div>
+            )}
+            {resendMessage && (
+              <div className={`alert mb-4 ${resendIsError ? "alert-danger" : "alert-success"}`}>
+                {resendMessage}
+              </div>
+            )}
             <form onSubmit={submit}>
               <div className="nb-field">
                 <label htmlFor="reg-email">Email</label>

--- a/frontend/src/pages/Register.test.jsx
+++ b/frontend/src/pages/Register.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { GOOGLE_LOGIN_URL, registerUser } from '../api/client';
+import { resendVerification } from '../api/client';
 
 const mockNavigate = vi.fn();
 const mockSetUser = vi.fn();
@@ -165,12 +166,61 @@ describe('Register page', () => {
     await waitFor(() => expect(screen.getByText('Registration failed.')).toBeInTheDocument());
 
     await user.click(screen.getByRole('button', { name: /register/i }));
-    await waitFor(() => expect(screen.queryByText('Registration failed.')).toBeNull());
+    await waitFor(() => expect(screen.queryByText('Registration failed.')).not.toBeInTheDocument());
   });
 
-  it('shows a verification success message and does not assume auth when no user payload is returned', async () => {
+  // ── Verification pending ──────────────────────────────────────────────
+
+  it('shows verification message with resend button when code is verification_pending', async () => {
     vi.mocked(registerUser).mockResolvedValue({
       detail: 'Registration successful. Please check your email to verify your account.',
+      code: 'verification_pending',
+    });
+    const user = userEvent.setup();
+
+    render(<Register />);
+
+    await user.type(screen.getByLabelText(/email/i), 'verify@example.com');
+    await user.type(screen.getByLabelText(/username/i), 'verifyuser');
+    await user.type(screen.getByLabelText(/password/i), 'securepass');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Registration successful. Please check your email to verify your account.')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument();
+    });
+    expect(mockSetUser).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not show resend button for non-verification success without username', async () => {
+    vi.mocked(registerUser).mockResolvedValue({ detail: 'Welcome aboard.' });
+    const user = userEvent.setup();
+
+    render(<Register />);
+
+    await user.type(screen.getByLabelText(/email/i), 'a@a.com');
+    await user.type(screen.getByLabelText(/username/i), 'auser');
+    await user.type(screen.getByLabelText(/password/i), 'pass');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Welcome aboard.')).toBeInTheDocument()
+    );
+    expect(screen.queryByRole('button', { name: /resend verification email/i })).not.toBeInTheDocument();
+  });
+
+  // ── Resend verification ───────────────────────────────────────────────
+
+  it('calls resendVerification with the registered email and shows success', async () => {
+    vi.mocked(registerUser).mockResolvedValue({
+      detail: 'Please check your email.',
+      code: 'verification_pending',
+    });
+    vi.mocked(resendVerification).mockResolvedValue({
+      detail: 'Verification email sent. Please check your inbox.',
     });
     const user = userEvent.setup();
 
@@ -182,11 +232,118 @@ describe('Register page', () => {
     await user.click(screen.getByRole('button', { name: /register/i }));
 
     await waitFor(() =>
-      expect(
-        screen.getByText('Registration successful. Please check your email to verify your account.')
-      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
     );
-    expect(mockSetUser).not.toHaveBeenCalled();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() => {
+      const alert = screen.getByText('Verification email sent. Please check your inbox.');
+      expect(alert).toBeInTheDocument();
+      expect(alert.closest('.alert')).toHaveClass('alert-success');
+    });
+    expect(resendVerification).toHaveBeenCalledWith('verify@example.com');
+  });
+
+  it('shows an error in a danger alert when resendVerification fails', async () => {
+    vi.mocked(registerUser).mockResolvedValue({
+      detail: 'Please check your email.',
+      code: 'verification_pending',
+    });
+    vi.mocked(resendVerification).mockRejectedValue({
+      response: { data: { detail: 'Failed to send verification email. Please try again later.' } },
+    });
+    const user = userEvent.setup();
+
+    render(<Register />);
+
+    await user.type(screen.getByLabelText(/email/i), 'verify@example.com');
+    await user.type(screen.getByLabelText(/username/i), 'verifyuser');
+    await user.type(screen.getByLabelText(/password/i), 'securepass');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() => {
+      const alert = screen.getByText('Failed to send verification email. Please try again later.');
+      expect(alert).toBeInTheDocument();
+      expect(alert.closest('.alert')).toHaveClass('alert-danger');
+    });
+  });
+
+  it('falls back to generic message when resend fails without detail', async () => {
+    vi.mocked(registerUser).mockResolvedValue({
+      detail: 'Please check your email.',
+      code: 'verification_pending',
+    });
+    vi.mocked(resendVerification).mockRejectedValue(new Error('network'));
+    const user = userEvent.setup();
+
+    render(<Register />);
+
+    await user.type(screen.getByLabelText(/email/i), 'verify@example.com');
+    await user.type(screen.getByLabelText(/username/i), 'verifyuser');
+    await user.type(screen.getByLabelText(/password/i), 'securepass');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Failed to resend verification email.')).toBeInTheDocument()
+    );
+  });
+
+  it('disables the resend button and shows spinner while resending', async () => {
+    vi.mocked(registerUser).mockResolvedValue({
+      detail: 'Please check your email.',
+      code: 'verification_pending',
+    });
+    vi.mocked(resendVerification).mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+
+    render(<Register />);
+
+    await user.type(screen.getByLabelText(/email/i), 'verify@example.com');
+    await user.type(screen.getByLabelText(/username/i), 'verifyuser');
+    await user.type(screen.getByLabelText(/password/i), 'securepass');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    expect(screen.getByRole('button', { name: /resend verification email/i })).toBeDisabled();
+    expect(document.querySelectorAll('.spinner-border').length).toBeGreaterThan(0);
+  });
+
+  it('uses fallback success message when resend response has no detail', async () => {
+    vi.mocked(registerUser).mockResolvedValue({
+      detail: 'Please check your email.',
+      code: 'verification_pending',
+    });
+    vi.mocked(resendVerification).mockResolvedValue({});
+    const user = userEvent.setup();
+
+    render(<Register />);
+
+    await user.type(screen.getByLabelText(/email/i), 'verify@example.com');
+    await user.type(screen.getByLabelText(/username/i), 'verifyuser');
+    await user.type(screen.getByLabelText(/password/i), 'securepass');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Verification email sent. Please check your inbox.')).toBeInTheDocument()
+    );
   });
 });

--- a/frontend/src/pages/Register.test.jsx
+++ b/frontend/src/pages/Register.test.jsx
@@ -195,6 +195,27 @@ describe('Register page', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('shows fallback verification message and resend button when detail is missing', async () => {
+    vi.mocked(registerUser).mockResolvedValue({ code: 'verification_pending' });
+    const user = userEvent.setup();
+
+    render(<Register />);
+
+    await user.type(screen.getByLabelText(/email/i), 'verify@example.com');
+    await user.type(screen.getByLabelText(/username/i), 'verifyuser');
+    await user.type(screen.getByLabelText(/password/i), 'securepass');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Registration successful. Please check your email to verify your account.')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument();
+    });
+    expect(mockSetUser).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('does not show resend button for non-verification success without username', async () => {
     vi.mocked(registerUser).mockResolvedValue({ detail: 'Welcome aboard.' });
     const user = userEvent.setup();

--- a/frontend/src/test/mocks/client.js
+++ b/frontend/src/test/mocks/client.js
@@ -31,6 +31,8 @@ export const createComment = vi.fn();
 export const updateComment = vi.fn();
 export const deleteComment = vi.fn();
 
+export const resendVerification = vi.fn();
+
 export const fetchCsrf = vi.fn();
 
 export default { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() };

--- a/tests/unit/test_views_auth.py
+++ b/tests/unit/test_views_auth.py
@@ -1,6 +1,8 @@
 """Unit tests for authentication API endpoints."""
 
 import io
+import smtplib
+from unittest.mock import patch
 
 import pytest
 from allauth.account.models import EmailAddress
@@ -9,6 +11,8 @@ from django.db import connection
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
+
+GENERIC_RESEND_DETAIL = "Verification email sent. Please check your inbox."
 
 
 # ── CSRF ───────────────────────────────────────────────────────────────────────
@@ -301,6 +305,7 @@ class TestEmailVerificationFlow:
             format="json",
         )
         assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["detail"] == GENERIC_RESEND_DETAIL
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_anonymous_with_valid_email_returns_200(
@@ -310,6 +315,19 @@ class TestEmailVerificationFlow:
         resp = api_client.post(
             "/api/auth/resend-verification/",
             {"email": user.email},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        assert "verification email sent" in resp.data["detail"].lower()
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
+    def test_resend_verification_anonymous_with_non_string_email_returns_200(
+        self, api_client
+    ):
+        """Non-string email payloads do not hit ORM and still return uniform 200."""
+        resp = api_client.post(
+            "/api/auth/resend-verification/",
+            {"email": [1]},
             format="json",
         )
         assert resp.status_code == status.HTTP_200_OK
@@ -326,12 +344,30 @@ class TestEmailVerificationFlow:
         )
         resp = auth_client.post("/api/auth/resend-verification/")
         assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["detail"] == GENERIC_RESEND_DETAIL
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_succeeds_for_unverified_user(self, auth_client):
         """Authenticated unverified users can request another verification email."""
         resp = auth_client.post("/api/auth/resend-verification/")
         assert resp.status_code == status.HTTP_200_OK
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
+    def test_resend_verification_hides_smtp_failure_for_anonymous_known_email(
+        self, api_client, user
+    ):
+        """SMTP failures still return 200 to avoid leaking valid unverified accounts."""
+        with patch(
+            "blog.api.write.router.send_verification_email_for_user",
+            side_effect=smtplib.SMTPException("mail transport unavailable"),
+        ):
+            resp = api_client.post(
+                "/api/auth/resend-verification/",
+                {"email": user.email},
+                format="json",
+            )
+        assert resp.status_code == status.HTTP_200_OK
+        assert "verification email sent" in resp.data["detail"].lower()
 
 
 # ── Logout ─────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_views_auth.py
+++ b/tests/unit/test_views_auth.py
@@ -245,6 +245,7 @@ class TestLoginView:
             format="json",
         )
         assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.data["code"] == "email_not_verified"
 
     @override_settings(
         ACCOUNT_EMAIL_VERIFICATION="mandatory",
@@ -280,16 +281,43 @@ class TestEmailVerificationFlow:
         assert resp.status_code == status.HTTP_201_CREATED
         assert "detail" in resp.data
         assert "username" not in resp.data
+        assert resp.data["code"] == "verification_pending"
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
-    def test_resend_verification_requires_authentication(self, api_client):
-        """Anonymous resend requests are rejected."""
+    def test_resend_verification_anonymous_without_email_returns_200(self, api_client):
+        """Anonymous resend without email returns 200 (no user enumeration)."""
         resp = api_client.post("/api/auth/resend-verification/")
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == status.HTTP_200_OK
+        assert "verification email sent" in resp.data["detail"].lower()
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
-    def test_resend_verification_returns_400_for_verified_user(self, auth_client, user):
-        """Already-verified users do not get another verification email."""
+    def test_resend_verification_anonymous_with_unknown_email_returns_200(
+        self, api_client
+    ):
+        """Anonymous resend with unknown email returns 200 (no enumeration)."""
+        resp = api_client.post(
+            "/api/auth/resend-verification/",
+            {"email": "nobody@example.com"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
+    def test_resend_verification_anonymous_with_valid_email_returns_200(
+        self, api_client, user
+    ):
+        """Anonymous resend with valid unverified email sends verification."""
+        resp = api_client.post(
+            "/api/auth/resend-verification/",
+            {"email": user.email},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        assert "verification email sent" in resp.data["detail"].lower()
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
+    def test_resend_verification_returns_200_for_verified_user(self, auth_client, user):
+        """Already-verified users get the same 200 response (no enumeration)."""
         EmailAddress.objects.create(
             user=user,
             email=user.email,
@@ -297,7 +325,7 @@ class TestEmailVerificationFlow:
             primary=True,
         )
         resp = auth_client.post("/api/auth/resend-verification/")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == status.HTTP_200_OK
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_succeeds_for_unverified_user(self, auth_client):


### PR DESCRIPTION
## Summary

- Backend `resend-verification` endpoint now accepts unauthenticated requests with an `email` field (uniform 200 to prevent user enumeration). Login 403 and register 201 responses include machine-readable `code` fields (`email_not_verified` / `verification_pending`) for stable client detection.
- New `useResendVerification` React hook with ref-based mutex eliminates duplicated resend logic across Login and Register, with proper alert styling (`alert-danger` / `alert-success`).
- Comprehensive tests: frontend coverage for resend success, failure, fallback messages, loading/disabled states, and alert styling; backend tests for the updated anonymous resend endpoint.

## Linked issues

Closes #42

## Test plan

- [x] Backend unit tests pass (pytest) — resend endpoint accepts anonymous requests, returns 200 for unknown/verified/valid emails
- [x] Frontend unit tests pass (vitest) — Login and Register resend flows, loading states, error/success alert styling, fallback messages
- [x] Pre-commit hooks pass (ruff check + format, eslint)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and email-verification flows and changes response semantics (new `code` fields; `resend-verification` now returns uniform 200s for anonymous/verified/unknown emails), which could affect clients and verification UX if mis-handled.
> 
> **Overview**
> Improves the email-verification UX by adding machine-readable response `code`s: login now returns `403` with `code: "email_not_verified"`, and mandatory-verification registration returns `201` with `code: "verification_pending"`.
> 
> Updates `POST /auth/resend-verification/` to accept anonymous requests with an optional `email` and to **avoid user enumeration** by returning the same success message (200) when the user is missing or already verified; only actual send failures return `500`.
> 
> Frontend integrates this via a new `useResendVerification` hook and adds “Resend verification email” actions + success/error alerts (with loading/disabled states) on both Login and Register, with expanded unit tests and updated API client mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603b22abdd94920bb1aa117e66a5bda5a1eccdd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resend verification available on login and registration screens with explicit UI (button, spinner, success/error alerts) and protection against duplicate requests.

* **Bug Fixes**
  * Anonymous resend now always returns a uniform success message (prevents account enumeration); verified-email and mail-send edge cases also return consistent responses for anonymous callers.
  * Login/register responses include structured codes for email verification states.

* **Tests**
  * Coverage updated for all resend and verification flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->