### PR TITLE
feat(tests): migrate API tests from DRF to Django test primitives

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 from django.contrib.auth.models import User
-from rest_framework.test import APIClient
+from django.test import Client
 
 from accounts.models import Profile
 from blog.models import Comment, Post, Tag
@@ -13,28 +13,28 @@ from blog.models import Comment, Post, Tag
 
 @pytest.fixture
 def api_client():
-    """Unauthenticated DRF test client."""
-    return APIClient()
+    """Unauthenticated Django test client."""
+    return Client()
 
 
 @pytest.fixture
 def auth_client(api_client, user):
-    """DRF test client authenticated as a regular user."""
-    api_client.force_authenticate(user=user)
+    """Django test client authenticated as a regular user."""
+    api_client.force_login(user)
     return api_client
 
 
 @pytest.fixture
 def mod_client(api_client, moderator):
-    """DRF test client authenticated as a moderator."""
-    api_client.force_authenticate(user=moderator)
+    """Django test client authenticated as a moderator."""
+    api_client.force_login(moderator)
     return api_client
 
 
 @pytest.fixture
 def admin_client(api_client, admin_user):
-    """DRF test client authenticated as an admin."""
-    api_client.force_authenticate(user=admin_user)
+    """Django test client authenticated as an admin."""
+    api_client.force_login(admin_user)
     return api_client
 
 

--- a/tests/unit/test_ninja_read_preview.py
+++ b/tests/unit/test_ninja_read_preview.py
@@ -3,8 +3,7 @@
 import json
 
 import pytest
-from rest_framework.test import APIClient
-from rest_framework import status
+from django.test import Client
 
 from blog.models import Comment, Post
 
@@ -15,32 +14,34 @@ class TestNinjaReadPreview:
 
     def test_openapi_json_is_available(self, api_client):
         resp = api_client.get("/api/_ninja/read/openapi.json")
-        assert resp.status_code == status.HTTP_200_OK
+        assert resp.status_code == 200
         assert json.loads(resp.content)["openapi"] == "3.1.0"
 
     def test_dashboard_returns_expected_sections(self, api_client):
         resp = api_client.get("/api/_ninja/read/dashboard/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert "stats" in resp.data
-        assert "latest_posts" in resp.data
-        assert "most_used_tags" in resp.data
+        data = resp.json()
+        assert resp.status_code == 200
+        assert "stats" in data
+        assert "latest_posts" in data
+        assert "most_used_tags" in data
 
     def test_post_list_is_paginated(self, api_client, post):
         resp = api_client.get("/api/_ninja/read/posts/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["count"] >= 1
-        assert "results" in resp.data
+        data = resp.json()
+        assert resp.status_code == 200
+        assert data["count"] >= 1
+        assert "results" in data
 
     def test_post_detail_honors_draft_visibility(self, api_client, user, draft_post):
-        owner_client = APIClient()
-        owner_client.force_authenticate(user=user)
+        owner_client = Client()
+        owner_client.force_login(user)
 
         anon = api_client.get(f"/api/_ninja/read/posts/{draft_post.slug}/")
         owner = owner_client.get(f"/api/_ninja/read/posts/{draft_post.slug}/")
 
-        assert anon.status_code == status.HTTP_404_NOT_FOUND
-        assert owner.status_code == status.HTTP_200_OK
-        assert owner.data["slug"] == draft_post.slug
+        assert anon.status_code == 404
+        assert owner.status_code == 200
+        assert owner.json()["slug"] == draft_post.slug
 
     def test_comment_list_excludes_draft_post_comments(self, api_client, user):
         draft = Post.objects.create(
@@ -71,8 +72,9 @@ class TestNinjaReadPreview:
         )
 
         resp = api_client.get("/api/_ninja/read/comments/")
-        assert resp.status_code == status.HTTP_200_OK
-        slugs = [item["post_slug"] for item in resp.data["results"]]
+        results = resp.json()["results"]
+        assert resp.status_code == 200
+        slugs = [item["post_slug"] for item in results]
         assert published.slug in slugs, "approved comment on published post must appear"
         assert draft.slug not in slugs, "comment on draft post must be excluded"
 
@@ -83,17 +85,18 @@ class TestNinjaReadPreview:
             f"/api/_ninja/read/users/{post.author.username}/comments/"
         )
 
-        assert list_resp.status_code == status.HTTP_200_OK
-        assert detail_resp.status_code == status.HTTP_200_OK
-        assert comments_resp.status_code == status.HTTP_200_OK
-        assert detail_resp.data["user"]["username"] == post.author.username
+        assert list_resp.status_code == 200
+        assert detail_resp.status_code == 200
+        assert comments_resp.status_code == 200
+        assert detail_resp.json()["user"]["username"] == post.author.username
         assert all(
-            item["author"] == str(post.author) for item in comments_resp.data["results"]
+            item["author"] == str(post.author)
+            for item in comments_resp.json()["results"]
         )
 
     def test_missing_user_routes_return_404(self, api_client):
         detail_resp = api_client.get("/api/_ninja/read/users/no-such-user/")
         comments_resp = api_client.get("/api/_ninja/read/users/no-such-user/comments/")
 
-        assert detail_resp.status_code == status.HTTP_404_NOT_FOUND
-        assert comments_resp.status_code == status.HTTP_404_NOT_FOUND
+        assert detail_resp.status_code == 404
+        assert comments_resp.status_code == 404

--- a/tests/unit/test_ninja_write_preview.py
+++ b/tests/unit/test_ninja_write_preview.py
@@ -6,9 +6,7 @@ from contextlib import contextmanager
 import pytest
 from django.conf import settings
 from django.core.cache import cache
-from django.test import override_settings
-from rest_framework import status
-from rest_framework.test import APIClient
+from django.test import Client, override_settings
 
 from blog.api import preview_write_api
 from blog.api.write import throttling as write_throttling
@@ -36,99 +34,99 @@ class TestNinjaWritePreview:
 
     def test_openapi_json_is_available(self, api_client):
         resp = api_client.get("/api/_ninja/write/openapi.json")
-        assert resp.status_code == status.HTTP_200_OK
+        assert resp.status_code == 200
         assert json.loads(resp.content)["openapi"] == "3.1.0"
 
     def test_posts_create_preserves_auth_requirements(self, user):
-        anon_client = APIClient()
-        auth_client = APIClient()
-        auth_client.force_authenticate(user=user)
+        anon_client = Client()
+        auth_client = Client()
+        auth_client.force_login(user)
 
         anon = anon_client.post(
             "/api/_ninja/write/posts/",
             {"title": "Preview Post", "body": "body"},
-            format="json",
+            content_type="application/json",
         )
         authed = auth_client.post(
             "/api/_ninja/write/posts/",
             {"title": "Preview Post", "body": "body"},
-            format="json",
+            content_type="application/json",
         )
 
-        assert anon.status_code == status.HTTP_401_UNAUTHORIZED
-        assert authed.status_code == status.HTTP_201_CREATED
-        assert authed.data["title"] == "Preview Post"
+        assert anon.status_code == 401
+        assert authed.status_code == 201
+        assert authed.json()["title"] == "Preview Post"
 
     def test_tag_create_respects_moderator_permissions(self, user, moderator):
-        user_client = APIClient()
-        user_client.force_authenticate(user=user)
-        mod_client = APIClient()
-        mod_client.force_authenticate(user=moderator)
+        user_client = Client()
+        user_client.force_login(user)
+        mod_client = Client()
+        mod_client.force_login(moderator)
 
         user_resp = user_client.post(
             "/api/_ninja/write/tags/",
             {"name": "not-allowed"},
-            format="json",
+            content_type="application/json",
         )
         mod_resp = mod_client.post(
             "/api/_ninja/write/tags/",
             {"name": "allowed-tag"},
-            format="json",
+            content_type="application/json",
         )
 
-        assert user_resp.status_code == status.HTTP_403_FORBIDDEN
-        assert mod_resp.status_code == status.HTTP_201_CREATED
+        assert user_resp.status_code == 403
+        assert mod_resp.status_code == 201
 
     def test_comment_vote_route_matches_existing_behavior(self, user, comment):
-        anon_client = APIClient()
-        auth_client = APIClient()
-        auth_client.force_authenticate(user=user)
+        anon_client = Client()
+        auth_client = Client()
+        auth_client.force_login(user)
 
         anon = anon_client.post(
             f"/api/_ninja/write/comments/{comment.id}/vote/",
             {"vote": "like"},
-            format="json",
+            content_type="application/json",
         )
         authed = auth_client.post(
             f"/api/_ninja/write/comments/{comment.id}/vote/",
             {"vote": "like"},
-            format="json",
+            content_type="application/json",
         )
 
-        assert anon.status_code == status.HTTP_401_UNAUTHORIZED
-        assert authed.status_code == status.HTTP_200_OK
-        assert authed.data["likes"] == 1
+        assert anon.status_code == 401
+        assert authed.status_code == 200
+        assert authed.json()["likes"] == 1
 
     def test_comment_create_rejects_invalid_parent_id(self, user, post):
-        client = APIClient()
-        client.force_authenticate(user=user)
+        client = Client()
+        client.force_login(user)
         resp = client.post(
             f"/api/_ninja/write/posts/{post.slug}/comments/",
             {"body": "reply", "parent_id": {"bad": "value"}},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Invalid parent_id."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid parent_id."
 
     def test_public_delete_route_dispatches_to_delete_handler(self, user, post):
-        anon_client = APIClient()
-        auth_client = APIClient()
-        auth_client.force_authenticate(user=user)
+        anon_client = Client()
+        auth_client = Client()
+        auth_client.force_login(user)
         post.author = user
         post.save(update_fields=["author"])
 
         anon_resp = anon_client.delete(f"/api/posts/{post.slug}/")
         auth_resp = auth_client.delete(f"/api/posts/{post.slug}/")
 
-        assert anon_resp.status_code == status.HTTP_401_UNAUTHORIZED
-        assert auth_resp.status_code == status.HTTP_204_NO_CONTENT
+        assert anon_resp.status_code == 401
+        assert auth_resp.status_code == 204
         assert Post.objects.filter(pk=post.pk).exists() is False
 
     def test_head_request_falls_back_to_get_dispatch(self, api_client):
         head_resp = api_client.head("/api/posts/")
         get_resp = api_client.get("/api/posts/")
-        assert head_resp.status_code == status.HTTP_200_OK
-        assert get_resp.status_code == status.HTTP_200_OK
+        assert head_resp.status_code == 200
+        assert get_resp.status_code == 200
 
     def test_login_route_rate_limits_with_low_scope_rate(self):
         assert preview_write_api.urls_namespace == "blog_ninja_write_preview"
@@ -155,21 +153,21 @@ class TestNinjaWritePreview:
             with _temporary_throttle_rate(
                 throttle, settings.API_THROTTLE_RATES["login"]
             ):
-                client = APIClient()
+                client = Client()
                 first = client.post(
                     "/api/_ninja/write/auth/login/",
                     {"email": "missing@example.com", "password": "wrongpass"},
-                    format="json",
+                    content_type="application/json",
                 )
                 second = client.post(
                     "/api/_ninja/write/auth/login/",
                     {"email": "missing@example.com", "password": "wrongpass"},
-                    format="json",
+                    content_type="application/json",
                 )
             cache.clear()
 
-        assert first.status_code == status.HTTP_400_BAD_REQUEST
-        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert first.status_code == 400
+        assert second.status_code == 429
 
     def test_resend_route_rate_limits_with_low_scope_rate(self, user):
         assert preview_write_api.urls_namespace == "blog_ninja_write_preview"
@@ -198,11 +196,11 @@ class TestNinjaWritePreview:
                 throttle,
                 settings.API_THROTTLE_RATES["resend_verification"],
             ):
-                client = APIClient()
-                client.force_authenticate(user=user)
+                client = Client()
+                client.force_login(user)
                 first = client.post("/api/_ninja/write/auth/resend-verification/")
                 second = client.post("/api/_ninja/write/auth/resend-verification/")
             cache.clear()
 
-        assert first.status_code == status.HTTP_200_OK
-        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert first.status_code == 200
+        assert second.status_code == 429

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -3,7 +3,7 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Count
-from rest_framework.test import APIRequestFactory
+from django.test import RequestFactory
 
 from blog.models import Tag
 from blog.serializers import (
@@ -146,7 +146,7 @@ class TestPostDetailSerializer:
 
     def test_includes_body_and_comments(self, post):
         """Detail serializer adds body and comments on top of list fields."""
-        factory = APIRequestFactory()
+        factory = RequestFactory()
         request = factory.get("/")
         request.user = AnonymousUser()
         data = PostDetailSerializer(post, context={"request": request}).data
@@ -155,7 +155,7 @@ class TestPostDetailSerializer:
 
     def test_comments_is_list(self, post, comment):
         """comments serializes as a list of comment objects."""
-        factory = APIRequestFactory()
+        factory = RequestFactory()
         request = factory.get("/")
         request.user = AnonymousUser()
         data = PostDetailSerializer(post, context={"request": request}).data
@@ -172,7 +172,7 @@ class TestCommentSerializer:
 
     def test_exposes_expected_fields(self, comment):
         """Serialized comment contains all expected fields."""
-        factory = APIRequestFactory()
+        factory = RequestFactory()
         request = factory.get("/")
         request.user = AnonymousUser()
         data = CommentSerializer(comment, context={"request": request}).data
@@ -189,7 +189,7 @@ class TestCommentSerializer:
 
     def test_likes_and_dislikes_default_to_zero(self, comment):
         """A new comment has zero likes and dislikes."""
-        factory = APIRequestFactory()
+        factory = RequestFactory()
         request = factory.get("/")
         request.user = AnonymousUser()
         data = CommentSerializer(comment, context={"request": request}).data
@@ -198,7 +198,7 @@ class TestCommentSerializer:
 
     def test_user_vote_is_none_for_anonymous(self, comment):
         """user_vote is None when the request has no authenticated user."""
-        factory = APIRequestFactory()
+        factory = RequestFactory()
         request = factory.get("/")
         request.user = AnonymousUser()
         data = CommentSerializer(comment, context={"request": request}).data
@@ -213,7 +213,7 @@ class TestPostWriteSerializerTagValidation:
     """Tests for PostWriteSerializer.validate_tag_ids."""
 
     def _make_context(self, user):
-        factory = APIRequestFactory()
+        factory = RequestFactory()
         request = factory.post("/")
         request.user = user
         return {"request": request}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
-from rest_framework.test import APIRequestFactory
+from django.test import RequestFactory
 
 from blog.api_views import can_manage_tags, paginate
 from blog.utils import build_unique_slug
@@ -107,7 +107,7 @@ class TestPaginate:
 
     def _make_request(self, page="1"):
         """Return a GET request with the given page parameter."""
-        factory = APIRequestFactory()
+        factory = RequestFactory()
         return factory.get("/", {"page": page})
 
     def test_returns_required_keys(self, db):

--- a/tests/unit/test_views_auth.py
+++ b/tests/unit/test_views_auth.py
@@ -8,9 +8,7 @@ import pytest
 from allauth.account.models import EmailAddress
 from django.contrib.auth.models import User
 from django.db import connection
-from django.test import override_settings
-from rest_framework import status
-from rest_framework.test import APIClient
+from django.test import Client, override_settings
 
 GENERIC_RESEND_DETAIL = "Verification email sent. Please check your inbox."
 
@@ -25,9 +23,9 @@ class TestCsrfView:
     def test_returns_200_and_csrf_token(self, api_client):
         """Anonymous requests receive a CSRF token in the response body."""
         resp = api_client.get("/api/auth/csrf/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert "csrfToken" in resp.data
-        assert resp.data["csrfToken"]
+        assert resp.status_code == 200
+        assert "csrfToken" in resp.json()
+        assert resp.json()["csrfToken"]
 
 
 # ── Register ───────────────────────────────────────────────────────────────────
@@ -46,17 +44,17 @@ class TestRegisterView:
                 "username": "newuser",
                 "password": "newpass123",
             },
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["username"] == "newuser"
+        assert resp.status_code == 201
+        assert resp.json()["username"] == "newuser"
 
     def test_creates_user_in_database(self, api_client):
         """Registration persists the new user to the database."""
         api_client.post(
             "/api/auth/register/",
             {"email": "db@example.com", "username": "dbuser", "password": "dbpass123"},
-            format="json",
+            content_type="application/json",
         )
         assert User.objects.filter(username="dbuser").exists()
 
@@ -69,7 +67,7 @@ class TestRegisterView:
                 "username": "mixedcaseuser",
                 "password": "newpass123",
             },
-            format="json",
+            content_type="application/json",
         )
         created_user = User.objects.get(username="mixedcaseuser")
         assert created_user.email == "mixedcase@example.com"
@@ -79,29 +77,29 @@ class TestRegisterView:
         resp = api_client.post(
             "/api/auth/register/",
             {"email": "incomplete@example.com"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_non_string_required_fields_return_400(self, api_client):
         """Non-string required fields are rejected with the standard missing-fields detail."""
         resp = api_client.post(
             "/api/auth/register/",
             {"email": ["bad"], "username": {"bad": "type"}, "password": 123},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "email, username and password are required."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "email, username and password are required."
 
     def test_duplicate_email_returns_400(self, api_client, user):
         """Registering with an already-used email returns 400."""
         resp = api_client.post(
             "/api/auth/register/",
             {"email": "test@example.com", "username": "other", "password": "pass1234"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Registration failed."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Registration failed."
 
     def test_duplicate_username_returns_400(self, api_client, user):
         """Registering with an already-taken username returns 400."""
@@ -112,17 +110,17 @@ class TestRegisterView:
                 "username": "testuser",
                 "password": "pass1234",
             },
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Registration failed."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Registration failed."
 
     def test_duplicate_registration_error_is_generic(self, api_client, user):
         """Duplicate registrations always return the same generic message regardless of which field collides."""
         resp_email = api_client.post(
             "/api/auth/register/",
             {"email": "test@example.com", "username": "other", "password": "pass1234"},
-            format="json",
+            content_type="application/json",
         )
         resp_username = api_client.post(
             "/api/auth/register/",
@@ -131,13 +129,13 @@ class TestRegisterView:
                 "username": "testuser",
                 "password": "pass1234",
             },
-            format="json",
+            content_type="application/json",
         )
-        assert resp_email.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp_username.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp_email.status_code == 400
+        assert resp_username.status_code == 400
         assert (
-            resp_email.data["detail"]
-            == resp_username.data["detail"]
+            resp_email.json()["detail"]
+            == resp_username.json()["detail"]
             == "Registration failed."
         )
 
@@ -150,11 +148,11 @@ class TestRegisterView:
                 "username": "weakuser",
                 "password": "123",
             },
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert "password" in resp.data
-        assert resp.data["password"]
+        assert resp.status_code == 400
+        assert "password" in resp.json()
+        assert resp.json()["password"]
 
 
 # ── Login ──────────────────────────────────────────────────────────────────────
@@ -169,45 +167,45 @@ class TestLoginView:
         resp = api_client.post(
             "/api/auth/login/",
             {"email": "test@example.com", "password": "testpass123"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["username"] == "testuser"
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "testuser"
 
     def test_wrong_password_returns_400(self, api_client, user):
         """An incorrect password returns 400 with an 'Invalid credentials' message."""
         resp = api_client.post(
             "/api/auth/login/",
             {"email": "test@example.com", "password": "wrongpass"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Invalid credentials."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid credentials."
 
     def test_unknown_email_returns_400(self, api_client):
         """A non-existent email returns 400."""
         resp = api_client.post(
             "/api/auth/login/",
             {"email": "nobody@example.com", "password": "pass"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_non_string_credentials_return_400(self, api_client):
         """NoSQL-style dict payloads must be rejected with 400, not cause a 500."""
         resp = api_client.post(
             "/api/auth/login/",
             {"email": {"$ne": ""}, "password": {"$ne": ""}},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Invalid credentials."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid credentials."
 
     def test_get_login_returns_json_405(self, api_client):
         """Unsupported methods return a JSON 405 payload with Allow header."""
         resp = api_client.get("/api/auth/login/")
-        assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-        assert resp.data["detail"] == "Method not allowed."
+        assert resp.status_code == 405
+        assert resp.json()["detail"] == "Method not allowed."
         assert "POST" in resp.headers.get("Allow", "")
 
     def test_duplicate_email_lookup_returns_400(self, api_client, monkeypatch):
@@ -220,20 +218,20 @@ class TestLoginView:
         resp = api_client.post(
             "/api/auth/login/",
             {"email": "test@example.com", "password": "testpass123"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Invalid credentials."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid credentials."
 
     def test_login_normalizes_email_before_lookup(self, api_client, user):
         """Login accepts equivalent emails with surrounding whitespace/case differences."""
         resp = api_client.post(
             "/api/auth/login/",
             {"email": "  TEST@EXAMPLE.COM  ", "password": "testpass123"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["username"] == "testuser"
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "testuser"
 
     @override_settings(
         ACCOUNT_EMAIL_VERIFICATION="mandatory",
@@ -246,10 +244,10 @@ class TestLoginView:
         resp = api_client.post(
             "/api/auth/login/",
             {"email": "test@example.com", "password": "testpass123"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
-        assert resp.data["code"] == "email_not_verified"
+        assert resp.status_code == 403
+        assert resp.json()["code"] == "email_not_verified"
 
     @override_settings(
         ACCOUNT_EMAIL_VERIFICATION="mandatory",
@@ -260,10 +258,10 @@ class TestLoginView:
         resp = api_client.post(
             "/api/auth/login/",
             {"email": "test@example.com", "password": "testpass123"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["username"] == "testuser"
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "testuser"
 
 
 @pytest.mark.django_db
@@ -280,19 +278,21 @@ class TestEmailVerificationFlow:
                 "username": "verifyuser",
                 "password": "newpass123",
             },
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert "detail" in resp.data
-        assert "username" not in resp.data
-        assert resp.data["code"] == "verification_pending"
+        assert resp.status_code == 201
+        assert "detail" in resp.json()
+        assert "username" not in resp.json()
+        assert resp.json()["code"] == "verification_pending"
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_anonymous_without_email_returns_200(self, api_client):
         """Anonymous resend without email returns 200 (no user enumeration)."""
-        resp = api_client.post("/api/auth/resend-verification/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert "verification email sent" in resp.data["detail"].lower()
+        resp = api_client.post(
+            "/api/auth/resend-verification/", content_type="application/json"
+        )
+        assert resp.status_code == 200
+        assert "verification email sent" in resp.json()["detail"].lower()
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_anonymous_with_unknown_email_returns_200(
@@ -302,10 +302,10 @@ class TestEmailVerificationFlow:
         resp = api_client.post(
             "/api/auth/resend-verification/",
             {"email": "nobody@example.com"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["detail"] == GENERIC_RESEND_DETAIL
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == GENERIC_RESEND_DETAIL
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_anonymous_with_valid_email_returns_200(
@@ -315,10 +315,10 @@ class TestEmailVerificationFlow:
         resp = api_client.post(
             "/api/auth/resend-verification/",
             {"email": user.email},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert "verification email sent" in resp.data["detail"].lower()
+        assert resp.status_code == 200
+        assert "verification email sent" in resp.json()["detail"].lower()
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_anonymous_with_non_string_email_returns_200(
@@ -328,10 +328,10 @@ class TestEmailVerificationFlow:
         resp = api_client.post(
             "/api/auth/resend-verification/",
             {"email": [1]},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert "verification email sent" in resp.data["detail"].lower()
+        assert resp.status_code == 200
+        assert "verification email sent" in resp.json()["detail"].lower()
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_returns_200_for_verified_user(self, auth_client, user):
@@ -343,14 +343,14 @@ class TestEmailVerificationFlow:
             primary=True,
         )
         resp = auth_client.post("/api/auth/resend-verification/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["detail"] == GENERIC_RESEND_DETAIL
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == GENERIC_RESEND_DETAIL
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_succeeds_for_unverified_user(self, auth_client):
         """Authenticated unverified users can request another verification email."""
         resp = auth_client.post("/api/auth/resend-verification/")
-        assert resp.status_code == status.HTTP_200_OK
+        assert resp.status_code == 200
 
     @override_settings(ACCOUNT_EMAIL_VERIFICATION="mandatory")
     def test_resend_verification_hides_smtp_failure_for_anonymous_known_email(
@@ -364,10 +364,10 @@ class TestEmailVerificationFlow:
             resp = api_client.post(
                 "/api/auth/resend-verification/",
                 {"email": user.email},
-                format="json",
+                content_type="application/json",
             )
-        assert resp.status_code == status.HTTP_200_OK
-        assert "verification email sent" in resp.data["detail"].lower()
+        assert resp.status_code == 200
+        assert "verification email sent" in resp.json()["detail"].lower()
 
 
 # ── Logout ─────────────────────────────────────────────────────────────────────
@@ -380,13 +380,13 @@ class TestLogoutView:
     def test_authenticated_logout_returns_200(self, auth_client):
         """An authenticated user can log out successfully."""
         resp = auth_client.post("/api/auth/logout/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["detail"] == "Logged out."
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == "Logged out."
 
     def test_unauthenticated_logout_returns_403(self, api_client):
         """An unauthenticated request to logout is rejected."""
         resp = api_client.post("/api/auth/logout/")
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.status_code == 403
 
 
 # ── Current User ───────────────────────────────────────────────────────────────
@@ -399,13 +399,13 @@ class TestCurrentUserView:
     def test_authenticated_returns_user_data(self, auth_client, user):
         """Authenticated users receive their own serialized data."""
         resp = auth_client.get("/api/auth/user/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["username"] == "testuser"
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "testuser"
 
     def test_unauthenticated_returns_403(self, api_client):
-        """Unauthenticated requests are rejected; DRF SessionAuthentication returns 403."""
+        """Unauthenticated requests are rejected with 403."""
         resp = api_client.get("/api/auth/user/")
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.status_code == 403
 
 
 # ── Update Profile ─────────────────────────────────────────────────────────────
@@ -418,53 +418,57 @@ class TestUpdateProfileView:
     def test_change_username_succeeds(self, auth_client):
         """Providing a new unique username updates it successfully."""
         resp = auth_client.patch(
-            "/api/auth/profile/", {"username": "newname"}, format="json"
+            "/api/auth/profile/",
+            {"username": "newname"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["username"] == "newname"
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "newname"
 
     def test_change_password_succeeds(self, auth_client):
         """Providing correct current password allows password change."""
         resp = auth_client.patch(
             "/api/auth/profile/",
             {"current_password": "testpass123", "new_password": "newpassword456"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
+        assert resp.status_code == 200
 
     def test_wrong_current_password_returns_400(self, auth_client):
         """An incorrect current password is rejected with a field error."""
         resp = auth_client.patch(
             "/api/auth/profile/",
             {"current_password": "wrongpass", "new_password": "newpassword456"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert "current_password" in resp.data
+        assert resp.status_code == 400
+        assert "current_password" in resp.json()
 
     def test_new_password_too_short_returns_400(self, auth_client):
         """A new password shorter than 8 characters is rejected."""
         resp = auth_client.patch(
             "/api/auth/profile/",
             {"current_password": "testpass123", "new_password": "short"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert "new_password" in resp.data
+        assert resp.status_code == 400
+        assert "new_password" in resp.json()
 
     def test_taken_username_returns_400(self, auth_client, db):
         """Attempting to take another user's username is rejected."""
         User.objects.create_user(username="taken", email="taken@x.com", password="p")
         resp = auth_client.patch(
-            "/api/auth/profile/", {"username": "taken"}, format="json"
+            "/api/auth/profile/", {"username": "taken"}, content_type="application/json"
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert "username" in resp.data
+        assert resp.status_code == 400
+        assert "username" in resp.json()
 
     def test_empty_username_returns_400(self, auth_client):
         """Submitting an empty string for username is rejected."""
-        resp = auth_client.patch("/api/auth/profile/", {"username": ""}, format="json")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        resp = auth_client.patch(
+            "/api/auth/profile/", {"username": ""}, content_type="application/json"
+        )
+        assert resp.status_code == 400
 
     def test_non_string_profile_fields_return_400(self, auth_client):
         """Non-string profile update fields return explicit validation errors."""
@@ -475,11 +479,11 @@ class TestUpdateProfileView:
                 "current_password": {"$ne": ""},
                 "new_password": ["bad"],
             },
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["username"] == "Username must be a string."
-        assert resp.data["new_password"] == "Password must be a string."
+        assert resp.status_code == 400
+        assert resp.json()["username"] == "Username must be a string."
+        assert resp.json()["new_password"] == "Password must be a string."
 
 
 # ── Google OAuth ────────────────────────────────────────────────────────────────
@@ -514,7 +518,7 @@ class TestGoogleOAuth:
         a POST is required to initiate the redirect.
         """
         resp = client.post("/accounts/google/login/")
-        assert resp.status_code == status.HTTP_302_FOUND
+        assert resp.status_code == 302
 
     def test_google_login_redirect_targets_google(self, client):
         """The POST redirect URL points to accounts.google.com."""
@@ -528,7 +532,6 @@ class TestGoogleOAuth:
         """A user created in any way (including via social login) auto-receives a Profile from signals."""
         from accounts.models import Profile
 
-        # Simulate what allauth does after completing the OAuth flow: save the user.
         u = User.objects.create_user(username="g_newuser", email="g_new@example.com")
         assert Profile.objects.filter(user=u).exists()
 
@@ -577,17 +580,17 @@ class TestGoogleOAuth:
         )
         Profile.objects.get_or_create(user=social_user)
 
-        client = APIClient()
-        client.force_authenticate(user=social_user)
+        client = Client()
+        client.force_login(social_user)
         resp = client.get("/api/auth/user/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["email"] == "g_api@example.com"
+        assert resp.status_code == 200
+        assert resp.json()["email"] == "g_api@example.com"
 
     def test_social_user_without_auth_cannot_access_user_endpoint(self, db):
         """An unauthenticated request is still rejected even for OAuth-created accounts."""
-        client = APIClient()
+        client = Client()
         resp = client.get("/api/auth/user/")
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.status_code == 403
 
     # ── ensure_sites_migrations command ────────────────────────────────────
 

--- a/tests/unit/test_views_comments.py
+++ b/tests/unit/test_views_comments.py
@@ -2,7 +2,6 @@
 
 import pytest
 from django.contrib.auth.models import User
-from rest_framework import status
 
 from blog.models import Comment, CommentVote, Post
 
@@ -17,15 +16,15 @@ class TestCommentList:
     def test_list_returns_200_for_anonymous(self, api_client, comment):
         """Anyone can list comments."""
         resp = api_client.get("/api/comments/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["count"] >= 1
+        assert resp.status_code == 200
+        assert resp.json()["count"] >= 1
 
     def test_list_response_is_paginated(self, api_client):
         """Response includes pagination metadata."""
-        resp = api_client.get("/api/comments/")
-        assert "count" in resp.data
-        assert "total_pages" in resp.data
-        assert "results" in resp.data
+        data = api_client.get("/api/comments/").json()
+        assert "count" in data
+        assert "total_pages" in data
+        assert "results" in data
 
     def test_list_excludes_comments_on_draft_posts(self, api_client, user):
         """Anonymous users do not see comments attached to draft posts."""
@@ -44,24 +43,27 @@ class TestCommentList:
         )
 
         resp = api_client.get("/api/comments/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert all(item["post_slug"] != "hidden-draft" for item in resp.data["results"])
+        assert resp.status_code == 200
+        assert all(
+            item["post_slug"] != "hidden-draft" for item in resp.json()["results"]
+        )
 
     def test_post_comments_list_returns_paginated_response(
         self, api_client, post, comment
     ):
         """GET /api/posts/<slug>/comments/ returns paginated comments for the post."""
         resp = api_client.get(f"/api/posts/{post.slug}/comments/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert "count" in resp.data
-        assert "total_pages" in resp.data
-        assert "results" in resp.data
-        assert all(item["post_slug"] == post.slug for item in resp.data["results"])
+        data = resp.json()
+        assert resp.status_code == 200
+        assert "count" in data
+        assert "total_pages" in data
+        assert "results" in data
+        assert all(item["post_slug"] == post.slug for item in data["results"])
 
     def test_post_comments_list_nonexistent_post_returns_404(self, api_client):
         """GET /api/posts/<slug>/comments/ returns 404 for missing posts."""
         resp = api_client.get("/api/posts/no-such-post/comments/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
 
 # ── Comment Create ─────────────────────────────────────────────────────────────
@@ -76,55 +78,55 @@ class TestCommentCreate:
         resp = auth_client.post(
             f"/api/posts/{post.slug}/comments/",
             {"body": "Great post!"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["body"] == "Great post!"
+        assert resp.status_code == 201
+        assert resp.json()["body"] == "Great post!"
 
     def test_unauthenticated_user_cannot_comment(self, api_client, post):
         """An unauthenticated user is rejected."""
         resp = api_client.post(
             f"/api/posts/{post.slug}/comments/",
             {"body": "Hey"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == 401
 
     def test_empty_body_returns_400(self, auth_client, post):
         """An empty comment body is rejected."""
         resp = auth_client.post(
             f"/api/posts/{post.slug}/comments/",
             {"body": ""},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_reply_to_existing_comment(self, auth_client, post, comment):
         """A reply links to the parent comment."""
         resp = auth_client.post(
             f"/api/posts/{post.slug}/comments/",
             {"body": "Reply!", "parent_id": comment.id},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
+        assert resp.status_code == 201
 
     def test_nonexistent_post_returns_404(self, auth_client):
         """Commenting on a non-existent post returns 404."""
         resp = auth_client.post(
             "/api/posts/no-post/comments/",
             {"body": "body"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_invalid_parent_id_returns_400(self, auth_client, post):
         """A parent_id that doesn't exist on the post returns 400."""
         resp = auth_client.post(
             f"/api/posts/{post.slug}/comments/",
             {"body": "body", "parent_id": 99999},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_regular_user_cannot_comment_on_another_users_draft(
         self, api_client, draft_post
@@ -135,22 +137,22 @@ class TestCommentCreate:
             email="other-draft@example.com",
             password="strongpass123",
         )
-        api_client.force_authenticate(user=other)
+        api_client.force_login(other)
         resp = api_client.post(
             f"/api/posts/{draft_post.slug}/comments/",
             {"body": "Sneaky"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_non_string_body_returns_400(self, auth_client, post):
         """Structured JSON payloads are rejected cleanly."""
         resp = auth_client.post(
             f"/api/posts/{post.slug}/comments/",
             {"body": {"$ne": ""}},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
 
 # ── Comment Update ─────────────────────────────────────────────────────────────
@@ -165,35 +167,41 @@ class TestCommentUpdate:
         resp = auth_client.patch(
             f"/api/comments/{comment.id}/",
             {"body": "Edited body"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["body"] == "Edited body"
+        assert resp.status_code == 200
+        assert resp.json()["body"] == "Edited body"
 
     def test_other_user_cannot_update_comment(self, api_client, comment, db):
         """A different user cannot edit someone else's comment."""
         other = User.objects.create_user(
             username="other", email="o@x.com", password="p"
         )
-        api_client.force_authenticate(user=other)
+        api_client.force_login(other)
         resp = api_client.patch(
-            f"/api/comments/{comment.id}/", {"body": "Hacked"}, format="json"
+            f"/api/comments/{comment.id}/",
+            {"body": "Hacked"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_empty_body_returns_400(self, auth_client, comment):
         """Setting comment body to empty is rejected."""
         resp = auth_client.patch(
-            f"/api/comments/{comment.id}/", {"body": ""}, format="json"
+            f"/api/comments/{comment.id}/",
+            {"body": ""},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_nonexistent_comment_returns_404(self, auth_client):
         """Updating a non-existent comment returns 404."""
         resp = auth_client.patch(
-            "/api/comments/99999/", {"body": "body"}, format="json"
+            "/api/comments/99999/",
+            {"body": "body"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
 
 # ── Comment Delete ─────────────────────────────────────────────────────────────
@@ -206,7 +214,7 @@ class TestCommentDelete:
     def test_author_can_delete_own_comment(self, auth_client, comment):
         """A comment author can delete their comment."""
         resp = auth_client.delete(f"/api/comments/{comment.id}/")
-        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert resp.status_code == 204
         assert not Comment.objects.filter(id=comment.id).exists()
 
     def test_other_user_cannot_delete_comment(self, api_client, comment, db):
@@ -214,14 +222,14 @@ class TestCommentDelete:
         other = User.objects.create_user(
             username="other2", email="o2@x.com", password="p"
         )
-        api_client.force_authenticate(user=other)
+        api_client.force_login(other)
         resp = api_client.delete(f"/api/comments/{comment.id}/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_nonexistent_comment_returns_404(self, auth_client):
         """Deleting a non-existent comment returns 404."""
         resp = auth_client.delete("/api/comments/99999/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
 
 # ── Comment Vote ───────────────────────────────────────────────────────────────
@@ -234,18 +242,22 @@ class TestCommentVote:
     def test_like_comment(self, auth_client, comment):
         """Liking a comment increments the likes count."""
         resp = auth_client.post(
-            f"/api/comments/{comment.id}/vote/", {"vote": "like"}, format="json"
+            f"/api/comments/{comment.id}/vote/",
+            {"vote": "like"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["likes"] == 1
+        assert resp.status_code == 200
+        assert resp.json()["likes"] == 1
 
     def test_dislike_comment(self, auth_client, comment):
         """Disliking a comment increments the dislikes count."""
         resp = auth_client.post(
-            f"/api/comments/{comment.id}/vote/", {"vote": "dislike"}, format="json"
+            f"/api/comments/{comment.id}/vote/",
+            {"vote": "dislike"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["dislikes"] == 1
+        assert resp.status_code == 200
+        assert resp.json()["dislikes"] == 1
 
     def test_voting_same_type_twice_toggles_off(self, auth_client, user, comment):
         """Sending the same vote twice removes the vote (toggle off)."""
@@ -253,10 +265,12 @@ class TestCommentVote:
             comment=comment, user=user, vote=CommentVote.VoteType.LIKE
         )
         resp = auth_client.post(
-            f"/api/comments/{comment.id}/vote/", {"vote": "like"}, format="json"
+            f"/api/comments/{comment.id}/vote/",
+            {"vote": "like"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["likes"] == 0
+        assert resp.status_code == 200
+        assert resp.json()["likes"] == 0
 
     def test_switching_vote_updates_counts(self, auth_client, user, comment):
         """Switching from like to dislike updates both counts correctly."""
@@ -264,32 +278,40 @@ class TestCommentVote:
             comment=comment, user=user, vote=CommentVote.VoteType.LIKE
         )
         resp = auth_client.post(
-            f"/api/comments/{comment.id}/vote/", {"vote": "dislike"}, format="json"
+            f"/api/comments/{comment.id}/vote/",
+            {"vote": "dislike"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["likes"] == 0
-        assert resp.data["dislikes"] == 1
+        assert resp.status_code == 200
+        assert resp.json()["likes"] == 0
+        assert resp.json()["dislikes"] == 1
 
     def test_invalid_vote_type_returns_400(self, auth_client, comment):
         """An unrecognised vote type is rejected."""
         resp = auth_client.post(
-            f"/api/comments/{comment.id}/vote/", {"vote": "invalid"}, format="json"
+            f"/api/comments/{comment.id}/vote/",
+            {"vote": "invalid"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_unauthenticated_vote_returns_401(self, api_client, comment):
         """Unauthenticated users cannot vote."""
         resp = api_client.post(
-            f"/api/comments/{comment.id}/vote/", {"vote": "like"}, format="json"
+            f"/api/comments/{comment.id}/vote/",
+            {"vote": "like"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == 401
 
     def test_vote_on_nonexistent_comment_returns_404(self, auth_client):
         """Voting on a non-existent comment returns 404."""
         resp = auth_client.post(
-            "/api/comments/99999/vote/", {"vote": "like"}, format="json"
+            "/api/comments/99999/vote/",
+            {"vote": "like"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_vote_on_comment_for_hidden_draft_returns_404(self, api_client, draft_post):
         """Users cannot interact with comments tied to hidden draft posts."""
@@ -305,8 +327,10 @@ class TestCommentVote:
             email="vote-user@example.com",
             password="strongpass123",
         )
-        api_client.force_authenticate(user=other)
+        api_client.force_login(other)
         resp = api_client.post(
-            f"/api/comments/{comment.id}/vote/", {"vote": "like"}, format="json"
+            f"/api/comments/{comment.id}/vote/",
+            {"vote": "like"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404

--- a/tests/unit/test_views_dashboard.py
+++ b/tests/unit/test_views_dashboard.py
@@ -2,7 +2,6 @@
 
 import pytest
 from django.contrib.auth.models import User
-from rest_framework import status
 
 from blog.models import Comment, Post, Tag
 
@@ -14,21 +13,20 @@ class TestDashboardView:
     def test_returns_200_for_anonymous(self, api_client):
         """Anyone can access the dashboard."""
         resp = api_client.get("/api/dashboard/")
-        assert resp.status_code == status.HTTP_200_OK
+        assert resp.status_code == 200
 
     def test_response_contains_top_level_keys(self, api_client):
         """Response includes all expected top-level sections."""
-        resp = api_client.get("/api/dashboard/")
-        assert "stats" in resp.data
-        assert "latest_posts" in resp.data
-        assert "most_commented_posts" in resp.data
-        assert "most_used_tags" in resp.data
-        assert "top_authors" in resp.data
+        data = api_client.get("/api/dashboard/").json()
+        assert "stats" in data
+        assert "latest_posts" in data
+        assert "most_commented_posts" in data
+        assert "most_used_tags" in data
+        assert "top_authors" in data
 
     def test_stats_contains_expected_fields(self, api_client):
         """stats section exposes all expected counters."""
-        resp = api_client.get("/api/dashboard/")
-        stats = resp.data["stats"]
+        stats = api_client.get("/api/dashboard/").json()["stats"]
         assert "total_posts" in stats
         assert "comments" in stats
         assert "authors" in stats
@@ -37,15 +35,13 @@ class TestDashboardView:
 
     def test_stats_reflect_created_content(self, api_client, post, comment):
         """Stats accurately count existing posts and comments."""
-        resp = api_client.get("/api/dashboard/")
-        stats = resp.data["stats"]
+        stats = api_client.get("/api/dashboard/").json()["stats"]
         assert stats["total_posts"] >= 1
         assert stats["comments"] >= 1
 
     def test_empty_database_returns_zero_stats(self, api_client, db):
         """All counters are 0 on an empty database."""
-        resp = api_client.get("/api/dashboard/")
-        stats = resp.data["stats"]
+        stats = api_client.get("/api/dashboard/").json()["stats"]
         assert stats["total_posts"] == 0
         assert stats["comments"] == 0
         assert stats["authors"] == 0
@@ -54,19 +50,19 @@ class TestDashboardView:
 
     def test_latest_posts_is_list(self, api_client):
         """latest_posts is always a list."""
-        resp = api_client.get("/api/dashboard/")
-        assert isinstance(resp.data["latest_posts"], list)
+        data = api_client.get("/api/dashboard/").json()
+        assert isinstance(data["latest_posts"], list)
 
     def test_top_authors_only_includes_authors_with_posts(self, api_client, post):
         """top_authors only lists users who have at least one post."""
-        resp = api_client.get("/api/dashboard/")
-        for author in resp.data["top_authors"]:
+        data = api_client.get("/api/dashboard/").json()
+        for author in data["top_authors"]:
             assert author["post_count"] > 0
 
     def test_average_depth_words_computed(self, api_client, post):
         """average_depth_words is a positive integer when posts exist."""
-        resp = api_client.get("/api/dashboard/")
-        assert resp.data["stats"]["average_depth_words"] > 0
+        data = api_client.get("/api/dashboard/").json()
+        assert data["stats"]["average_depth_words"] > 0
 
     def test_draft_post_comments_excluded_from_comment_count(self, api_client, db):
         """Comments on draft posts are not counted in the stats comment total."""
@@ -87,8 +83,8 @@ class TestDashboardView:
             is_approved=True,
         )
         resp = api_client.get("/api/dashboard/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["stats"]["comments"] == 0
+        assert resp.status_code == 200
+        assert resp.json()["stats"]["comments"] == 0
 
     def test_most_used_tags_excludes_draft_posts(self, api_client, db):
         """Tags attached only to draft posts appear with a post_count of 0 or are absent."""
@@ -104,9 +100,8 @@ class TestDashboardView:
             status=Post.Status.DRAFT,
         )
         draft.tags.add(tag)
-        resp = api_client.get("/api/dashboard/")
-        assert resp.status_code == status.HTTP_200_OK
-        tag_entries = [t for t in resp.data["most_used_tags"] if t["slug"] == tag.slug]
+        data = api_client.get("/api/dashboard/").json()
+        tag_entries = [t for t in data["most_used_tags"] if t["slug"] == tag.slug]
         assert not tag_entries or tag_entries[0]["post_count"] == 0
 
     def test_top_authors_excludes_draft_only_authors(self, api_client, db):
@@ -121,7 +116,6 @@ class TestDashboardView:
             body="Draft body.",
             status=Post.Status.DRAFT,
         )
-        resp = api_client.get("/api/dashboard/")
-        assert resp.status_code == status.HTTP_200_OK
-        author_usernames = [a["username"] for a in resp.data["top_authors"]]
+        data = api_client.get("/api/dashboard/").json()
+        author_usernames = [a["username"] for a in data["top_authors"]]
         assert draft_author.username not in author_usernames

--- a/tests/unit/test_views_posts.py
+++ b/tests/unit/test_views_posts.py
@@ -2,7 +2,6 @@
 
 import pytest
 from django.contrib.auth.models import User
-from rest_framework import status
 
 from blog.models import Post
 
@@ -17,100 +16,107 @@ class TestPostList:
     def test_list_posts_returns_200_for_anonymous(self, api_client, post):
         """Anyone can list posts."""
         resp = api_client.get("/api/posts/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["count"] >= 1
+        assert resp.status_code == 200
+        assert resp.json()["count"] >= 1
 
     def test_list_response_is_paginated(self, api_client, post):
         """Response contains pagination metadata."""
         resp = api_client.get("/api/posts/")
-        assert "count" in resp.data
-        assert "total_pages" in resp.data
-        assert "results" in resp.data
+        data = resp.json()
+        assert "count" in data
+        assert "total_pages" in data
+        assert "results" in data
 
     def test_create_post_authenticated_returns_201(self, auth_client):
         """An authenticated user can create a post."""
         resp = auth_client.post(
             "/api/posts/",
             {"title": "New Post", "body": "Some body text."},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["title"] == "New Post"
+        assert resp.status_code == 201
+        assert resp.json()["title"] == "New Post"
 
     def test_create_post_unauthenticated_returns_401(self, api_client):
         """Unauthenticated users cannot create posts."""
         resp = api_client.post(
-            "/api/posts/", {"title": "Fail", "body": "Fail"}, format="json"
+            "/api/posts/",
+            {"title": "Fail", "body": "Fail"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == 401
 
     def test_create_post_missing_title_returns_400(self, auth_client):
         """A post without a title is rejected."""
-        resp = auth_client.post("/api/posts/", {"body": "body only"}, format="json")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        resp = auth_client.post(
+            "/api/posts/", {"body": "body only"}, content_type="application/json"
+        )
+        assert resp.status_code == 400
 
     def test_create_post_missing_body_returns_400(self, auth_client):
         """A post without a body is rejected."""
-        resp = auth_client.post("/api/posts/", {"title": "title only"}, format="json")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        resp = auth_client.post(
+            "/api/posts/", {"title": "title only"}, content_type="application/json"
+        )
+        assert resp.status_code == 400
 
     def test_create_post_invalid_status_returns_400(self, auth_client):
         """An unrecognised status value is rejected."""
         resp = auth_client.post(
             "/api/posts/",
             {"title": "Bad Status", "body": "body", "status": "invalid"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_create_post_rejects_non_string_fields(self, auth_client):
         """Structured payloads for title/body do not crash the endpoint."""
         resp = auth_client.post(
             "/api/posts/",
             {"title": {"$ne": ""}, "body": "body"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_create_post_with_tags(self, auth_client, tag):
         """Tags are attached when tag_ids are provided."""
         resp = auth_client.post(
             "/api/posts/",
             {"title": "Tagged Post", "body": "body", "tag_ids": [tag.id]},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert any(t["slug"] == tag.slug for t in resp.data["tags"])
+        assert resp.status_code == 201
+        assert any(t["slug"] == tag.slug for t in resp.json()["tags"])
 
     def test_create_post_with_nonexistent_tag_ids_returns_400(self, auth_client):
         """Nonexistent tag IDs are rejected with a 400 response."""
         resp = auth_client.post(
             "/api/posts/",
             {"title": "Bad Tags", "body": "body", "tag_ids": [99999]},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert "tag_ids" in resp.data
+        assert resp.status_code == 400
+        assert "tag_ids" in resp.json()
 
     def test_create_published_post_sets_published_at(self, auth_client):
         """Creating a published post populates published_at."""
         resp = auth_client.post(
             "/api/posts/",
             {"title": "Live Post", "body": "body", "status": "published"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["published_at"] is not None
+        assert resp.status_code == 201
+        assert resp.json()["published_at"] is not None
 
     def test_create_draft_post_leaves_published_at_null(self, auth_client):
         """Creating a draft post leaves published_at as null."""
         resp = auth_client.post(
             "/api/posts/",
             {"title": "Draft Post", "body": "body", "status": "draft"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["published_at"] is None
+        assert resp.status_code == 201
+        assert resp.json()["published_at"] is None
 
 
 # ── Post Detail ────────────────────────────────────────────────────────────────
@@ -123,51 +129,59 @@ class TestPostDetail:
     def test_get_existing_post_returns_200(self, api_client, post):
         """Anyone can retrieve a post by slug."""
         resp = api_client.get(f"/api/posts/{post.slug}/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["slug"] == post.slug
+        assert resp.status_code == 200
+        assert resp.json()["slug"] == post.slug
 
     def test_get_nonexistent_post_returns_404(self, api_client):
         """A missing slug returns 404."""
         resp = api_client.get("/api/posts/no-such-post/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_get_post_includes_comments(self, api_client, post, comment):
         """Detail response includes a comments list."""
         resp = api_client.get(f"/api/posts/{post.slug}/")
-        assert "comments" in resp.data
+        assert "comments" in resp.json()
 
     def test_update_own_post_returns_200(self, auth_client, post):
         """An author can update their own post."""
         resp = auth_client.patch(
-            f"/api/posts/{post.slug}/", {"title": "Updated Title"}, format="json"
+            f"/api/posts/{post.slug}/",
+            {"title": "Updated Title"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["title"] == "Updated Title"
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Updated Title"
 
     def test_update_other_user_post_returns_403(self, api_client, post, db):
         """A user cannot edit another user's post."""
         other = User.objects.create_user(
             username="other", email="other@x.com", password="p"
         )
-        api_client.force_authenticate(user=other)
+        api_client.force_login(other)
         resp = api_client.patch(
-            f"/api/posts/{post.slug}/", {"title": "Hacked"}, format="json"
+            f"/api/posts/{post.slug}/",
+            {"title": "Hacked"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.status_code == 403
 
     def test_moderator_can_update_any_post(self, mod_client, post):
         """Moderators can edit any post regardless of authorship."""
         resp = mod_client.patch(
-            f"/api/posts/{post.slug}/", {"title": "Mod Edited"}, format="json"
+            f"/api/posts/{post.slug}/",
+            {"title": "Mod Edited"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
+        assert resp.status_code == 200
 
     def test_update_unauthenticated_returns_401(self, api_client, post):
         """Unauthenticated PATCH requests are rejected."""
         resp = api_client.patch(
-            f"/api/posts/{post.slug}/", {"title": "Anon"}, format="json"
+            f"/api/posts/{post.slug}/",
+            {"title": "Anon"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == 401
 
     def test_update_unauthenticated_nonexistent_slug_still_returns_401(
         self, api_client
@@ -176,23 +190,27 @@ class TestPostDetail:
         resp = api_client.patch(
             "/api/posts/no-such-post/",
             {"title": "Anon"},
-            format="json",
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == 401
 
     def test_update_empty_title_returns_400(self, auth_client, post):
         """Setting title to an empty string is rejected."""
         resp = auth_client.patch(
-            f"/api/posts/{post.slug}/", {"title": ""}, format="json"
+            f"/api/posts/{post.slug}/",
+            {"title": ""},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_update_empty_body_returns_400(self, auth_client, post):
         """Setting body to an empty string is rejected."""
         resp = auth_client.patch(
-            f"/api/posts/{post.slug}/", {"body": ""}, format="json"
+            f"/api/posts/{post.slug}/",
+            {"body": ""},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_update_malformed_json_returns_400(self, auth_client, post):
         """Malformed JSON is rejected instead of being treated as an empty PATCH."""
@@ -202,53 +220,55 @@ class TestPostDetail:
             "{not-json",
             content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Malformed JSON body."
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Malformed JSON body."
 
     def test_update_rejects_non_string_title(self, auth_client, post):
         """Structured payloads do not crash post updates."""
         resp = auth_client.patch(
-            f"/api/posts/{post.slug}/", {"title": {"$ne": ""}}, format="json"
+            f"/api/posts/{post.slug}/",
+            {"title": {"$ne": ""}},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_delete_own_post_returns_204(self, auth_client, post):
         """An author can delete their own post."""
         resp = auth_client.delete(f"/api/posts/{post.slug}/")
-        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert resp.status_code == 204
         assert not Post.objects.filter(slug=post.slug).exists()
 
     def test_delete_unauthenticated_returns_401(self, api_client, post):
         """Unauthenticated DELETE requests are rejected."""
         resp = api_client.delete(f"/api/posts/{post.slug}/")
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == 401
 
     def test_delete_unauthenticated_nonexistent_slug_still_returns_401(
         self, api_client
     ):
         """Delete checks auth before slug lookup to reduce oracle surface."""
         resp = api_client.delete("/api/posts/no-such-post/")
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code == 401
 
     def test_delete_other_user_post_returns_403(self, api_client, post, db):
         """A user cannot delete another user's post."""
         other = User.objects.create_user(
             username="other2", email="other2@x.com", password="p"
         )
-        api_client.force_authenticate(user=other)
+        api_client.force_login(other)
         resp = api_client.delete(f"/api/posts/{post.slug}/")
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.status_code == 403
 
     def test_get_draft_post_returns_404_for_anonymous(self, api_client, draft_post):
         """Anonymous users receive 404 when requesting a draft post."""
         resp = api_client.get(f"/api/posts/{draft_post.slug}/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_get_draft_post_returns_200_for_author(self, auth_client, draft_post):
         """The post author can retrieve their own draft post."""
         resp = auth_client.get(f"/api/posts/{draft_post.slug}/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["slug"] == draft_post.slug
+        assert resp.status_code == 200
+        assert resp.json()["slug"] == draft_post.slug
 
     def test_get_draft_post_returns_404_for_other_authenticated_user(
         self, api_client, draft_post, db
@@ -257,11 +277,11 @@ class TestPostDetail:
         other = User.objects.create_user(
             username="other3", email="other3@x.com", password="p"
         )
-        api_client.force_authenticate(user=other)
+        api_client.force_login(other)
         resp = api_client.get(f"/api/posts/{draft_post.slug}/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_get_draft_post_returns_200_for_moderator(self, mod_client, draft_post):
         """Moderators can view draft posts authored by other users."""
         resp = mod_client.get(f"/api/posts/{draft_post.slug}/")
-        assert resp.status_code == status.HTTP_200_OK
+        assert resp.status_code == 200

--- a/tests/unit/test_views_tags.py
+++ b/tests/unit/test_views_tags.py
@@ -2,7 +2,6 @@
 
 import pytest
 from django.contrib.auth.models import User
-from rest_framework import status
 
 from accounts.models import Profile
 from blog.models import Post, Tag
@@ -18,61 +17,75 @@ class TestTagList:
     def test_list_tags_returns_200_for_anonymous(self, api_client, tag):
         """Anyone can list tags."""
         resp = api_client.get("/api/tags/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["count"] >= 1
+        assert resp.status_code == 200
+        assert resp.json()["count"] >= 1
 
     def test_list_response_is_paginated(self, api_client):
         """Response contains pagination metadata."""
-        resp = api_client.get("/api/tags/")
-        assert "count" in resp.data
-        assert "total_pages" in resp.data
-        assert "results" in resp.data
+        data = api_client.get("/api/tags/").json()
+        assert "count" in data
+        assert "total_pages" in data
+        assert "results" in data
 
     def test_moderator_can_create_tag(self, mod_client):
         """A moderator can create a new tag."""
-        resp = mod_client.post("/api/tags/", {"name": "Django"}, format="json")
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["name"] == "django"
+        resp = mod_client.post(
+            "/api/tags/", {"name": "Django"}, content_type="application/json"
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "django"
 
     def test_admin_can_create_tag(self, admin_client):
         """An admin can create a new tag."""
-        resp = admin_client.post("/api/tags/", {"name": "Flask"}, format="json")
-        assert resp.status_code == status.HTTP_201_CREATED
+        resp = admin_client.post(
+            "/api/tags/", {"name": "Flask"}, content_type="application/json"
+        )
+        assert resp.status_code == 201
 
     def test_regular_user_cannot_create_tag(self, auth_client):
         """A regular user is forbidden from creating tags."""
-        resp = auth_client.post("/api/tags/", {"name": "Python"}, format="json")
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        resp = auth_client.post(
+            "/api/tags/", {"name": "Python"}, content_type="application/json"
+        )
+        assert resp.status_code == 403
 
     def test_unauthenticated_cannot_create_tag(self, api_client):
         """An anonymous user must authenticate before creating tags."""
-        resp = api_client.post("/api/tags/", {"name": "Django"}, format="json")
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        resp = api_client.post(
+            "/api/tags/", {"name": "Django"}, content_type="application/json"
+        )
+        assert resp.status_code == 401
 
     def test_duplicate_tag_name_returns_400(self, mod_client, db):
         """Creating a tag with a name that already exists returns 400."""
         Tag.objects.create(name="django", slug="django")
-        resp = mod_client.post("/api/tags/", {"name": "Django"}, format="json")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Tag name already exists."
+        resp = mod_client.post(
+            "/api/tags/", {"name": "Django"}, content_type="application/json"
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Tag name already exists."
 
     def test_empty_name_returns_400(self, mod_client):
         """An empty tag name is rejected."""
-        resp = mod_client.post("/api/tags/", {"name": ""}, format="json")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        resp = mod_client.post(
+            "/api/tags/", {"name": ""}, content_type="application/json"
+        )
+        assert resp.status_code == 400
 
     def test_non_string_name_returns_400(self, mod_client):
         """Structured payloads are rejected cleanly."""
-        resp = mod_client.post("/api/tags/", {"name": {"$ne": ""}}, format="json")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        resp = mod_client.post(
+            "/api/tags/", {"name": {"$ne": ""}}, content_type="application/json"
+        )
+        assert resp.status_code == 400
 
     def test_create_generates_slug(self, mod_client):
         """A created tag receives an auto-generated slug."""
         resp = mod_client.post(
-            "/api/tags/", {"name": "Machine Learning"}, format="json"
+            "/api/tags/", {"name": "Machine Learning"}, content_type="application/json"
         )
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["slug"] == "machine-learning"
+        assert resp.status_code == 201
+        assert resp.json()["slug"] == "machine-learning"
 
 
 # ── Tag Detail ─────────────────────────────────────────────────────────────────
@@ -85,13 +98,13 @@ class TestTagDetail:
     def test_get_tag_returns_200(self, api_client, tag):
         """Anyone can retrieve a tag by slug."""
         resp = api_client.get(f"/api/tags/{tag.slug}/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["tag"]["slug"] == tag.slug
+        assert resp.status_code == 200
+        assert resp.json()["tag"]["slug"] == tag.slug
 
     def test_get_tag_includes_posts(self, api_client, tag):
         """Tag detail response includes a posts list."""
         resp = api_client.get(f"/api/tags/{tag.slug}/")
-        assert "results" in resp.data
+        assert "results" in resp.json()
 
     def test_tag_detail_post_count_only_counts_published_posts(
         self, api_client, tag, user
@@ -115,47 +128,53 @@ class TestTagDetail:
         draft_post.tags.add(tag)
 
         resp = api_client.get(f"/api/tags/{tag.slug}/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["tag"]["post_count"] == 1
+        assert resp.status_code == 200
+        assert resp.json()["tag"]["post_count"] == 1
 
     def test_get_nonexistent_tag_returns_404(self, api_client):
         """A missing tag slug returns 404."""
         resp = api_client.get("/api/tags/no-such-tag/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
     def test_moderator_can_update_tag(self, mod_client, tag):
         """A moderator can rename a tag."""
         resp = mod_client.patch(
-            f"/api/tags/{tag.slug}/", {"name": "updated python"}, format="json"
+            f"/api/tags/{tag.slug}/",
+            {"name": "updated python"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["name"] == "updated python"
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "updated python"
 
     def test_regular_user_cannot_update_tag(self, auth_client, tag):
         """A regular user is forbidden from updating tags."""
         resp = auth_client.patch(
-            f"/api/tags/{tag.slug}/", {"name": "Hack"}, format="json"
+            f"/api/tags/{tag.slug}/",
+            {"name": "Hack"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.status_code == 403
 
     def test_update_duplicate_name_returns_400(self, mod_client, tag, db):
         """Renaming a tag to an existing name is rejected."""
         Tag.objects.create(name="django", slug="django")
         resp = mod_client.patch(
-            f"/api/tags/{tag.slug}/", {"name": "Django"}, format="json"
+            f"/api/tags/{tag.slug}/",
+            {"name": "Django"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_moderator_can_delete_tag(self, mod_client, tag):
         """A moderator can delete a tag."""
         resp = mod_client.delete(f"/api/tags/{tag.slug}/")
-        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert resp.status_code == 204
         assert not Tag.objects.filter(slug=tag.slug).exists()
 
     def test_regular_user_cannot_delete_tag(self, auth_client, tag):
         """A regular user is forbidden from deleting tags."""
         resp = auth_client.delete(f"/api/tags/{tag.slug}/")
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.status_code == 403
 
 
 # ── Tag lowercase normalisation ────────────────────────────────────────────────
@@ -167,59 +186,75 @@ class TestTagLowercaseNormalisation:
 
     def test_uppercase_input_stored_as_lowercase_on_create(self, mod_client):
         """Uppercase name is normalised to lowercase when created."""
-        resp = mod_client.post("/api/tags/", {"name": "FASTAPI"}, format="json")
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["name"] == "fastapi"
+        resp = mod_client.post(
+            "/api/tags/", {"name": "FASTAPI"}, content_type="application/json"
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "fastapi"
         assert Tag.objects.filter(name="fastapi").exists()
 
     def test_mixed_case_input_stored_as_lowercase_on_create(self, mod_client):
         """Mixed-case name is normalised to lowercase when created."""
-        resp = mod_client.post("/api/tags/", {"name": "CelEry"}, format="json")
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["name"] == "celery"
+        resp = mod_client.post(
+            "/api/tags/", {"name": "CelEry"}, content_type="application/json"
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "celery"
 
     def test_already_lowercase_input_unchanged_on_create(self, mod_client):
         """Lowercase input passes through unchanged."""
-        resp = mod_client.post("/api/tags/", {"name": "redis"}, format="json")
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["name"] == "redis"
+        resp = mod_client.post(
+            "/api/tags/", {"name": "redis"}, content_type="application/json"
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "redis"
 
     def test_uppercase_input_stored_as_lowercase_on_update(self, mod_client, tag):
         """Uppercase name is normalised to lowercase on update."""
         resp = mod_client.patch(
-            f"/api/tags/{tag.slug}/", {"name": "PYTHON"}, format="json"
+            f"/api/tags/{tag.slug}/",
+            {"name": "PYTHON"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["name"] == "python"
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "python"
 
     def test_mixed_case_input_stored_as_lowercase_on_update(self, mod_client, tag):
         """Mixed-case name is normalised to lowercase on update."""
         resp = mod_client.patch(
-            f"/api/tags/{tag.slug}/", {"name": "PyThOn TipS"}, format="json"
+            f"/api/tags/{tag.slug}/",
+            {"name": "PyThOn TipS"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["name"] == "python tips"
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "python tips"
 
     def test_duplicate_check_is_case_insensitive_on_create(self, mod_client, db):
         """Creating 'DJANGO' is rejected when 'django' already exists."""
         Tag.objects.create(name="django", slug="django")
-        resp = mod_client.post("/api/tags/", {"name": "DJANGO"}, format="json")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
-        assert resp.data["detail"] == "Tag name already exists."
+        resp = mod_client.post(
+            "/api/tags/", {"name": "DJANGO"}, content_type="application/json"
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Tag name already exists."
 
     def test_duplicate_check_is_case_insensitive_on_update(self, mod_client, tag, db):
         """Renaming to 'DJANGO' is rejected when 'django' already exists."""
         Tag.objects.create(name="django", slug="django")
         resp = mod_client.patch(
-            f"/api/tags/{tag.slug}/", {"name": "DJANGO"}, format="json"
+            f"/api/tags/{tag.slug}/",
+            {"name": "DJANGO"},
+            content_type="application/json",
         )
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.status_code == 400
 
     def test_whitespace_is_stripped_before_normalisation(self, mod_client):
         """Leading/trailing whitespace is stripped before lowercasing."""
-        resp = mod_client.post("/api/tags/", {"name": "  Pytest  "}, format="json")
-        assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.data["name"] == "pytest"
+        resp = mod_client.post(
+            "/api/tags/", {"name": "  Pytest  "}, content_type="application/json"
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "pytest"
 
 
 # ── can_manage_tags in user serializer ────────────────────────────────────────
@@ -232,7 +267,7 @@ class TestCanManageTagsSerializerField:
     def _get_user_data(self, client):
         resp = client.get("/api/auth/user/")
         assert resp.status_code == 200
-        return resp.data
+        return resp.json()
 
     def test_regular_user_cannot_manage_tags(self, auth_client):
         """Regular user has can_manage_tags=False."""
@@ -257,7 +292,7 @@ class TestCanManageTagsSerializerField:
             password="pass",  # noqa: S106
         )
         Profile.objects.get_or_create(user=su)
-        api_client.force_authenticate(user=su)
+        api_client.force_login(su)
         data = self._get_user_data(api_client)
         assert data["can_manage_tags"] is True
 
@@ -270,6 +305,6 @@ class TestCanManageTagsSerializerField:
             is_staff=True,
         )
         Profile.objects.get_or_create(user=staff)
-        api_client.force_authenticate(user=staff)
+        api_client.force_login(staff)
         data = self._get_user_data(api_client)
         assert data["can_manage_tags"] is True

--- a/tests/unit/test_views_users.py
+++ b/tests/unit/test_views_users.py
@@ -1,7 +1,6 @@
 """Unit tests for public user read endpoints."""
 
 import pytest
-from rest_framework import status
 
 
 @pytest.mark.django_db
@@ -10,14 +9,15 @@ class TestUserListView:
 
     def test_list_users_returns_200(self, api_client, user):
         resp = api_client.get("/api/users/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["count"] >= 1
+        assert resp.status_code == 200
+        assert resp.json()["count"] >= 1
 
     def test_list_users_is_paginated(self, api_client):
         resp = api_client.get("/api/users/")
-        assert "count" in resp.data
-        assert "total_pages" in resp.data
-        assert "results" in resp.data
+        data = resp.json()
+        assert "count" in data
+        assert "total_pages" in data
+        assert "results" in data
 
 
 @pytest.mark.django_db
@@ -26,13 +26,14 @@ class TestUserDetailView:
 
     def test_detail_returns_user_and_posts(self, api_client, post):
         resp = api_client.get(f"/api/users/{post.author.username}/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.data["user"]["username"] == post.author.username
-        assert "results" in resp.data
+        data = resp.json()
+        assert resp.status_code == 200
+        assert data["user"]["username"] == post.author.username
+        assert "results" in data
 
     def test_detail_returns_404_for_missing_user(self, api_client):
         resp = api_client.get("/api/users/no-such-user/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404
 
 
 @pytest.mark.django_db
@@ -41,13 +42,12 @@ class TestUserCommentsView:
 
     def test_comments_returns_paginated_results(self, api_client, comment):
         resp = api_client.get(f"/api/users/{comment.author.username}/comments/")
-        assert resp.status_code == status.HTTP_200_OK
-        assert "results" in resp.data
-        assert len(resp.data["results"]) > 0, "fixture comment must appear in results"
-        assert all(
-            item["author"] == str(comment.author) for item in resp.data["results"]
-        )
+        data = resp.json()
+        assert resp.status_code == 200
+        assert "results" in data
+        assert len(data["results"]) > 0, "fixture comment must appear in results"
+        assert all(item["author"] == str(comment.author) for item in data["results"])
 
     def test_comments_returns_404_for_missing_user(self, api_client):
         resp = api_client.get("/api/users/no-such-user/comments/")
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Migrates all backend API tests off DRF-specific testing primitives so the suite validates the Ninja implementation directly using Django-native tools.

- **`APIClient` → `django.test.Client`** and **`force_authenticate` → `force_login`** across `conftest.py` and all 10 test modules
- **`rest_framework.status` constants → plain integers**, **`resp.data` → `resp.json()`**, **`format="json"` → `content_type="application/json"`**
- **`APIRequestFactory` → `django.test.RequestFactory`** in serializer and utility tests
- Zero `rest_framework` imports remain in test code; all 245 tests pass

## Test plan

- [x] `uv run pytest tests/unit/ -x` — 245 passed, 1 skipped (PG-only), 0 failed
- [x] `uv run ruff check conftest.py tests/unit/` — all checks passed
- [x] Pre-commit hooks pass (ruff, ruff-format, trailing whitespace, etc.)
- [x] Verified on both `feat/tys-177-frontend-ninja-integration` and `master`

## Linked issues

Linear: [TYS-176](https://linear.app/tystar/issue/TYS-176/migrate-backend-api-tests-off-drf-specific-assumptions)
Closes #41

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use Django's native testing utilities instead of Django REST Framework utilities across all test modules.
  * Standardized HTTP status code assertions and response parsing to use Django's test client conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->