### PR TITLE
feat(dashboard): cold-start loading skeleton + copy

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -9,6 +9,73 @@ function fmt(dateStr) {
   });
 }
 
+function DashboardLoading() {
+  const skelListRows = (count) =>
+    Array.from({ length: count }, (_, j) => (
+      <div key={j} className="nb-list-item nb-skel-item" aria-hidden>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="nb-skel nb-skel-title" />
+          <div className="nb-skel nb-skel-meta" />
+        </div>
+        <div className="nb-skel nb-skel-badge" />
+      </div>
+    ));
+
+  return (
+    <div className="nb-layout-full" role="status" aria-live="polite" aria-busy="true">
+      <div className="nb-dashboard-loading-banner">
+        <div className="spinner-border" aria-hidden />
+        <p className="nb-dashboard-loading-hint">
+          Loading dashboard data. If the backend is waking up (typical on free hosting), this can take up to about a minute.
+        </p>
+      </div>
+
+      <div style={{ borderBottom: "var(--border)", display: "grid", gridTemplateColumns: "repeat(5, 1fr)" }}>
+        {Array.from({ length: 5 }, (_, i) => (
+          <div
+            key={i}
+            style={{ borderRight: i < 4 ? "var(--border)" : "none", padding: "24px", background: "var(--white)" }}
+            aria-hidden
+          >
+            <div className="nb-skel nb-skel-stat-value" />
+            <div className="nb-skel nb-skel-stat-label" />
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", borderBottom: "var(--border)" }}>
+        <div style={{ borderRight: "var(--border)" }}>
+          <div className="nb-card-header">Latest Posts</div>
+          <div className="nb-card-body">{skelListRows(6)}</div>
+        </div>
+        <div>
+          <div className="nb-card-header">Most Commented</div>
+          <div className="nb-card-body">{skelListRows(6)}</div>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr" }}>
+        <div style={{ borderRight: "var(--border)", borderBottom: "var(--border)" }}>
+          <div className="nb-card-header">Most Used Tags</div>
+          <div style={{ padding: "20px", display: "flex", flexWrap: "wrap", gap: "8px" }} aria-hidden>
+            {Array.from({ length: 8 }, (_, k) => (
+              <div key={k} className="nb-skel nb-skel-chip" />
+            ))}
+          </div>
+        </div>
+        <div style={{ borderBottom: "var(--border)" }}>
+          <div className="nb-card-header">Top Authors</div>
+          <div style={{ padding: "20px", display: "flex", flexWrap: "wrap", gap: "8px" }} aria-hidden>
+            {Array.from({ length: 8 }, (_, k) => (
+              <div key={k} className="nb-skel nb-skel-chip" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function Dashboard() {
   const [data, setData] = useState(null);
 
@@ -23,11 +90,7 @@ export default function Dashboard() {
   }, []);
 
   if (!data) {
-    return (
-      <div className="nb-layout-full nb-spinner">
-        <div className="spinner-border" />
-      </div>
-    );
+    return <DashboardLoading />;
   }
 
   const stats = data.stats ?? {};

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -81,12 +81,16 @@ const EMPTY_PAYLOAD = {
 };
 
 describe('Dashboard', () => {
-  it('shows loading spinner before data arrives', () => {
+  it('shows loading skeleton and hint before data arrives', () => {
     vi.mocked(fetchDashboard).mockReturnValue(new Promise(() => {}));
 
     render(<Dashboard />);
 
     expect(document.querySelector('.spinner-border')).not.toBeNull();
+    expect(
+      screen.getByText(/Loading dashboard data/i)
+    ).toBeInTheDocument();
+    expect(document.querySelector('.nb-skel-stat-value')).not.toBeNull();
   });
 
   it('renders stat cards after successful fetch', async () => {

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1437,6 +1437,83 @@ h1, h2, h3, h4, h5, h6 {
   padding: 60px 0;
 }
 
+.nb-dashboard-loading-banner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 20px 20px;
+  border-bottom: var(--border);
+  background: var(--white);
+}
+
+.nb-dashboard-loading-hint {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-align: center;
+  max-width: 36rem;
+  margin: 0;
+  line-height: 1.55;
+  opacity: 0.75;
+}
+
+.nb-skel {
+  background: var(--bg-mid);
+  border: var(--border-2);
+  animation: nb-skel-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes nb-skel-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nb-skel {
+    animation: none;
+    opacity: 0.85;
+  }
+}
+
+.nb-skel-stat-value {
+  height: 36px;
+  margin-bottom: 12px;
+  max-width: 80%;
+}
+
+.nb-skel-stat-label {
+  height: 14px;
+  max-width: 60%;
+}
+
+.nb-skel-title {
+  height: 18px;
+  margin-bottom: 8px;
+}
+
+.nb-skel-meta {
+  height: 12px;
+  max-width: 70%;
+}
+
+.nb-skel-badge {
+  width: 48px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.nb-skel-chip {
+  width: 88px;
+  height: 28px;
+}
+
+.nb-skel-item {
+  pointer-events: none;
+}
+
 .spinner-border {
   color: var(--black) !important;
   border-color: var(--black) !important;


### PR DESCRIPTION
## Summary

Replaces the dashboard spinner-only state with a full-layout skeleton, cold-start copy, and a11y-friendly loading region.

## Linear

[TYS-182 — Dashboard: cold-start loading skeleton + copy](https://linear.app/tystar/issue/TYS-182/dashboard-cold-start-loading-skeleton-copy)

## Changes

- `DashboardLoading`: banner + spinner + explanation; skeleton grids for stats, lists, chips
- `theme.css`: `.nb-dashboard-loading-*`, `.nb-skel*` with `prefers-reduced-motion` support
- `Dashboard.test.jsx`: loading state assertions

Closes #63

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dashboard loading experience with a skeleton UI displaying placeholder content layout instead of a simple spinner, providing better visual continuity while data loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->