### PR TITLE
feat(nav): mobile menu for primary links

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -2,18 +2,42 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { fetchDashboard } from "../api/client";
 import { useEffect, useState } from "react";
+import { useNarrowHeader } from "../hooks/useNarrowHeader";
+
+const PRIMARY_LINKS = [
+  { path: "/posts", label: "Posts" },
+  { path: "/tags", label: "Tags" },
+  { path: "/users", label: "Users" },
+  { path: "/comments", label: "Comments" },
+];
 
 export default function Navbar() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
+  const narrowHeader = useNarrowHeader();
   const [tickerStats, setTickerStats] = useState(null);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
     fetchDashboard()
       .then((data) => setTickerStats(data?.stats ?? { failed: true }))
       .catch(() => setTickerStats({ failed: true }));
   }, []);
+
+  useEffect(() => {
+    const id = window.requestAnimationFrame(() => setMobileMenuOpen(false));
+    return () => window.cancelAnimationFrame(id);
+  }, [location.pathname, narrowHeader]);
+
+  useEffect(() => {
+    if (!mobileMenuOpen || !narrowHeader) return;
+    const onKey = (e) => {
+      if (e.key === "Escape") setMobileMenuOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mobileMenuOpen, narrowHeader]);
 
   const handleLogout = async () => {
     await logout();
@@ -43,36 +67,47 @@ export default function Navbar() {
       ]
     : null;
 
+  const primaryNavList = (variant) => (
+    <ul className={variant === "desktop" ? "nb-nav" : "nb-nav-mobile-list"}>
+      {PRIMARY_LINKS.map(({ path, label }) => (
+        <li key={path}>
+          <Link to={path} className={isActive(path) ? "active" : ""}>
+            {label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+
   return (
     <>
       <header className="nb-header">
         <div className="nb-header-inner">
           <Link className="nb-brand" to="/dashboard">TheBlog</Link>
 
-          <nav aria-label="Primary">
-            <ul className="nb-nav">
-              <li>
-                <Link to="/posts" className={isActive("/posts") ? "active" : ""}>
-                  Posts
-                </Link>
-              </li>
-              <li>
-                <Link to="/tags" className={isActive("/tags") ? "active" : ""}>
-                  Tags
-                </Link>
-              </li>
-              <li>
-                <Link to="/users" className={isActive("/users") ? "active" : ""}>
-                  Users
-                </Link>
-              </li>
-              <li>
-                <Link to="/comments" className={isActive("/comments") ? "active" : ""}>
-                  Comments
-                </Link>
-              </li>
-            </ul>
-          </nav>
+          {!narrowHeader && (
+            <nav aria-label="Primary" className="nb-primary-desktop">
+              {primaryNavList("desktop")}
+            </nav>
+          )}
+
+          {narrowHeader && (
+            <button
+              type="button"
+              className="nb-menu-toggle"
+              aria-expanded={mobileMenuOpen}
+              aria-controls="nb-mobile-primary-nav"
+              id="nb-menu-toggle"
+              aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+              onClick={() => setMobileMenuOpen((o) => !o)}
+            >
+              <span className="nb-menu-toggle-bars" aria-hidden>
+                <span />
+                <span />
+                <span />
+              </span>
+            </button>
+          )}
 
           <div className="nb-header-right">
             {user ? (
@@ -115,6 +150,12 @@ export default function Navbar() {
             )}
           </div>
         </div>
+
+        {narrowHeader && mobileMenuOpen && (
+          <div className="nb-mobile-drawer" id="nb-mobile-primary-nav">
+            <nav aria-label="Primary">{primaryNavList("mobile")}</nav>
+          </div>
+        )}
       </header>
 
       {tickerItems && (

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { fetchDashboard } from "../api/client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNarrowHeader } from "../hooks/useNarrowHeader";
 
 const PRIMARY_LINKS = [
@@ -18,6 +18,8 @@ export default function Navbar() {
   const narrowHeader = useNarrowHeader();
   const [tickerStats, setTickerStats] = useState(null);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const prevPathRef = useRef(null);
+  const prevNarrowRef = useRef(null);
 
   useEffect(() => {
     fetchDashboard()
@@ -25,9 +27,23 @@ export default function Navbar() {
       .catch(() => setTickerStats({ failed: true }));
   }, []);
 
+  // Close the mobile drawer only when route or breakpoint mode actually changes — not on every
+  // mount tick. requestAnimationFrame(close) raced with open clicks in some CI/jsdom timings.
   useEffect(() => {
-    const id = window.requestAnimationFrame(() => setMobileMenuOpen(false));
-    return () => window.cancelAnimationFrame(id);
+    const path = location.pathname;
+    const narrow = narrowHeader;
+    if (prevPathRef.current === null && prevNarrowRef.current === null) {
+      prevPathRef.current = path;
+      prevNarrowRef.current = narrow;
+      return;
+    }
+    const pathChanged = prevPathRef.current !== path;
+    const narrowChanged = prevNarrowRef.current !== narrow;
+    prevPathRef.current = path;
+    prevNarrowRef.current = narrow;
+    if (pathChanged || narrowChanged) {
+      queueMicrotask(() => setMobileMenuOpen(false));
+    }
   }, [location.pathname, narrowHeader]);
 
   useEffect(() => {

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -4,13 +4,17 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation, useSearchParams } from "react-router-dom";
 import { vi } from "vitest";
 import { fetchDashboard } from "../api/client";
-import { NARROW_HEADER_QUERY } from "../hooks/useNarrowHeader";
-
 vi.mock("../api/client", () => import("../test/mocks/client.js"));
+
+/** Same breakpoint as useNarrowHeader; tolerate spacing differences from the runtime. */
+function isNarrowHeaderQuery(query) {
+  const q = String(query).trim().toLowerCase().replace(/\s+/g, " ");
+  return q.includes("max-width") && q.includes("900px");
+}
 
 function mockMatchMediaHeader(narrow) {
   window.matchMedia = vi.fn().mockImplementation((query) => ({
-    matches: query === NARROW_HEADER_QUERY ? narrow : false,
+    matches: isNarrowHeaderQuery(query) ? narrow : false,
     media: query,
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -4,8 +4,18 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation, useSearchParams } from "react-router-dom";
 import { vi } from "vitest";
 import { fetchDashboard } from "../api/client";
+import { NARROW_HEADER_QUERY } from "../hooks/useNarrowHeader";
 
 vi.mock("../api/client", () => import("../test/mocks/client.js"));
+
+function mockMatchMediaHeader(narrow) {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches: query === NARROW_HEADER_QUERY ? narrow : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
 
 const authStore = { user: null, logout: vi.fn() };
 
@@ -34,6 +44,7 @@ afterEach(() => {
 
 describe("Navbar", () => {
   beforeEach(() => {
+    mockMatchMediaHeader(false);
     authStore.user = { username: "alice", profile: { role: "user" } };
     vi.mocked(fetchDashboard).mockResolvedValue({
       stats: {
@@ -134,5 +145,49 @@ describe("Navbar", () => {
     await user.click(screen.getByRole("link", { name: "+ New Post" }));
 
     await waitFor(() => expect(screen.getByTestId("echo-open-create")).toHaveTextContent("yes"));
+  });
+
+  it("narrow header shows menu control instead of inline Posts link", async () => {
+    mockMatchMediaHeader(true);
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    expect(screen.queryByRole("navigation", { name: "Primary" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Open navigation menu" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens mobile drawer with primary links", async () => {
+    mockMatchMediaHeader(true);
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
+    expect(screen.getByRole("link", { name: "Posts" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Tags" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close navigation menu" })).toBeInTheDocument();
+  });
+
+  it("closes mobile menu on Escape", async () => {
+    mockMatchMediaHeader(true);
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
+    expect(screen.getByRole("link", { name: "Posts" })).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("link", { name: "Posts" })).toBeNull();
   });
 });

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -175,7 +175,7 @@ describe("Navbar", () => {
     );
     await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
-    expect(screen.getByRole("link", { name: "Posts" })).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: "Posts" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Tags" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Close navigation menu" })).toBeInTheDocument();
   });
@@ -190,7 +190,7 @@ describe("Navbar", () => {
     );
     await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
-    expect(screen.getByRole("link", { name: "Posts" })).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: "Posts" })).toBeInTheDocument();
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("link", { name: "Posts" })).toBeNull();
   });

--- a/frontend/src/hooks/useNarrowHeader.js
+++ b/frontend/src/hooks/useNarrowHeader.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/** Sync with `theme.css` @media (max-width: 900px) for `.nb-header`. */
+export const NARROW_HEADER_QUERY = "(max-width: 900px)";
+
+export function useNarrowHeader() {
+  const [narrow, setNarrow] = useState(() =>
+    typeof window !== "undefined" && window.matchMedia(NARROW_HEADER_QUERY).matches,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia(NARROW_HEADER_QUERY);
+    const onChange = () => setNarrow(mq.matches);
+    onChange();
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return narrow;
+}

--- a/frontend/src/hooks/useNarrowHeader.js
+++ b/frontend/src/hooks/useNarrowHeader.js
@@ -3,13 +3,28 @@ import { useEffect, useState } from "react";
 /** Sync with `theme.css` @media (max-width: 900px) for `.nb-header`. */
 export const NARROW_HEADER_QUERY = "(max-width: 900px)";
 
+function readNarrow() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  try {
+    return window.matchMedia(NARROW_HEADER_QUERY).matches;
+  } catch {
+    return false;
+  }
+}
+
 export function useNarrowHeader() {
-  const [narrow, setNarrow] = useState(() =>
-    typeof window !== "undefined" && window.matchMedia(NARROW_HEADER_QUERY).matches,
-  );
+  const [narrow, setNarrow] = useState(readNarrow);
 
   useEffect(() => {
-    const mq = window.matchMedia(NARROW_HEADER_QUERY);
+    if (typeof window.matchMedia !== "function") return;
+    let mq;
+    try {
+      mq = window.matchMedia(NARROW_HEADER_QUERY);
+    } catch {
+      return;
+    }
     const onChange = () => setNarrow(mq.matches);
     onChange();
     mq.addEventListener("change", onChange);

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -438,6 +438,94 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--sage);
 }
 
+.nb-primary-desktop {
+  display: flex;
+  align-items: stretch;
+}
+
+.nb-menu-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-left: var(--border);
+  background: var(--white);
+  color: var(--black);
+  padding: 14px 18px;
+  cursor: pointer;
+  margin: 0;
+  min-width: 52px;
+  transition: background 0.1s, color 0.1s;
+}
+
+.nb-menu-toggle:hover {
+  background: var(--black);
+  color: var(--sage);
+}
+
+.nb-menu-toggle[aria-expanded="true"] {
+  background: var(--black);
+  color: var(--sage);
+}
+
+.nb-menu-toggle-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 22px;
+}
+
+.nb-menu-toggle-bars span {
+  display: block;
+  height: 3px;
+  background: var(--black);
+  border: 1px solid var(--black);
+}
+
+.nb-menu-toggle:hover .nb-menu-toggle-bars span,
+.nb-menu-toggle[aria-expanded="true"] .nb-menu-toggle-bars span {
+  background: currentColor;
+  border-color: currentColor;
+}
+
+.nb-mobile-drawer {
+  border-bottom: var(--border);
+  background: var(--white);
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.nb-nav-mobile-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nb-nav-mobile-list li {
+  border-top: var(--border-2);
+}
+
+.nb-nav-mobile-list li:first-child {
+  border-top: none;
+}
+
+.nb-nav-mobile-list a {
+  display: block;
+  padding: 16px 24px;
+  text-decoration: none;
+  color: var(--black);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.nb-nav-mobile-list a:hover,
+.nb-nav-mobile-list a.active {
+  background: var(--black);
+  color: var(--sage);
+}
+
 /* ─── Ticker ─── */
 .nb-ticker {
   border-bottom: var(--border);
@@ -1549,10 +1637,6 @@ h1, h2, h3, h4, h5, h6 {
   .nb-hero-bar {
     gap: 20px;
     padding: 20px;
-  }
-
-  .nb-nav {
-    display: none;
   }
 
   .nb-content-area {

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// jsdom may omit matchMedia; some environments parse max-width against a tiny viewport
+// and return matches: true, which hides the desktop navbar. Default to "wide" for tests.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});


### PR DESCRIPTION
## Summary

Adds a hamburger control and full-width drawer so Posts / Tags / Users / Comments stay reachable below the 900px header breakpoint (replacing the old `display: none` on `.nb-nav` with no alternative).

## Linear

[TYS-183](https://linear.app/tystar/issue/TYS-183/site-mobile-navigation-when-primary-nav-is-hidden)

## Implementation

- `useNarrowHeader` — `matchMedia('(max-width: 900px)')` kept in sync with `theme.css`
- Conditional render: desktop inline nav vs mobile toggle + drawer
- Drawer closes on navigation, Escape, or when widening past the breakpoint

Closes #64

Made with [Cursor](https://cursor.com)