### PR TITLE
feat(dashboard): responsive stats row and content grids

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -30,42 +30,38 @@ function DashboardLoading() {
         </p>
       </div>
 
-      <div style={{ borderBottom: "var(--border)", display: "grid", gridTemplateColumns: "repeat(5, 1fr)" }}>
+      <div className="nb-dashboard-stats">
         {Array.from({ length: 5 }, (_, i) => (
-          <div
-            key={i}
-            style={{ borderRight: i < 4 ? "var(--border)" : "none", padding: "24px", background: "var(--white)" }}
-            aria-hidden
-          >
+          <div key={i} className="nb-dashboard-stat-cell" aria-hidden>
             <div className="nb-skel nb-skel-stat-value" />
             <div className="nb-skel nb-skel-stat-label" />
           </div>
         ))}
       </div>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", borderBottom: "var(--border)" }}>
-        <div style={{ borderRight: "var(--border)" }}>
+      <div className="nb-dashboard-two-col">
+        <div className="nb-dashboard-panel nb-dashboard-panel--divider-right">
           <div className="nb-card-header">Latest Posts</div>
           <div className="nb-card-body">{skelListRows(6)}</div>
         </div>
-        <div>
+        <div className="nb-dashboard-panel">
           <div className="nb-card-header">Most Commented</div>
           <div className="nb-card-body">{skelListRows(6)}</div>
         </div>
       </div>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr" }}>
-        <div style={{ borderRight: "var(--border)", borderBottom: "var(--border)" }}>
+      <div className="nb-dashboard-tags-row">
+        <div className="nb-dashboard-panel nb-dashboard-panel--divider-right">
           <div className="nb-card-header">Most Used Tags</div>
-          <div style={{ padding: "20px", display: "flex", flexWrap: "wrap", gap: "8px" }} aria-hidden>
+          <div className="nb-dashboard-chip-area" aria-hidden>
             {Array.from({ length: 8 }, (_, k) => (
               <div key={k} className="nb-skel nb-skel-chip" />
             ))}
           </div>
         </div>
-        <div style={{ borderBottom: "var(--border)" }}>
+        <div className="nb-dashboard-panel">
           <div className="nb-card-header">Top Authors</div>
-          <div style={{ padding: "20px", display: "flex", flexWrap: "wrap", gap: "8px" }} aria-hidden>
+          <div className="nb-dashboard-chip-area" aria-hidden>
             {Array.from({ length: 8 }, (_, k) => (
               <div key={k} className="nb-skel nb-skel-chip" />
             ))}
@@ -99,7 +95,7 @@ export default function Dashboard() {
     <div className="nb-layout-full">
 
       {/* Stats row */}
-      <div style={{ borderBottom: "var(--border)", display: "grid", gridTemplateColumns: "repeat(5, 1fr)" }}>
+      <div className="nb-dashboard-stats">
         {[
           { label: "Total Posts", value: stats.total_posts ?? 0, to: "/posts" },
           { label: "Comments", value: stats.comments ?? 0, to: "/comments" },
@@ -107,10 +103,7 @@ export default function Dashboard() {
           { label: "Active Tags", value: stats.active_tags ?? 0, to: "/tags" },
           { label: "Avg Words", value: stats.average_depth_words ?? 0, to: null },
         ].map((s, i) => (
-          <div
-            key={i}
-            style={{ borderRight: i < 4 ? "var(--border)" : "none", padding: "24px", background: "var(--white)" }}
-          >
+          <div key={i} className="nb-dashboard-stat-cell">
             {s.to ? (
               <Link to={s.to} style={{ textDecoration: "none", display: "block" }}>
                 <div className="nb-stat-value">{s.value}</div>
@@ -127,10 +120,10 @@ export default function Dashboard() {
       </div>
 
       {/* Content grid */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", borderBottom: "var(--border)" }}>
+      <div className="nb-dashboard-two-col">
 
         {/* Latest Posts */}
-        <div style={{ borderRight: "var(--border)" }}>
+        <div className="nb-dashboard-panel nb-dashboard-panel--divider-right">
           <div className="nb-card-header">
             Latest Posts
           </div>
@@ -156,7 +149,7 @@ export default function Dashboard() {
         </div>
 
         {/* Most Commented */}
-        <div>
+        <div className="nb-dashboard-panel">
           <div className="nb-card-header">
             Most Commented
           </div>
@@ -197,12 +190,12 @@ export default function Dashboard() {
       </div>
 
       {/* Tags + Authors row */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr" }}>
+      <div className="nb-dashboard-tags-row">
 
         {/* Most Used Tags */}
-        <div style={{ borderRight: "var(--border)", borderBottom: "var(--border)" }}>
+        <div className="nb-dashboard-panel nb-dashboard-panel--divider-right">
           <div className="nb-card-header">Most Used Tags</div>
-          <div style={{ padding: "20px", display: "flex", flexWrap: "wrap", gap: "8px" }}>
+          <div className="nb-dashboard-chip-area">
             {data.most_used_tags.length === 0 && (
               <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No tags yet.</span>
             )}
@@ -221,9 +214,9 @@ export default function Dashboard() {
         </div>
 
         {/* Top Authors */}
-        <div style={{ borderBottom: "var(--border)" }}>
+        <div className="nb-dashboard-panel">
           <div className="nb-card-header">Top Authors</div>
-          <div style={{ padding: "20px", display: "flex", flexWrap: "wrap", gap: "8px" }}>
+          <div className="nb-dashboard-chip-area">
             {data.top_authors.length === 0 && (
               <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No authors yet.</span>
             )}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -582,6 +582,54 @@ h1, h2, h3, h4, h5, h6 {
   min-height: calc(100vh - 95px);
 }
 
+/* ─── Dashboard responsive grids ─── */
+.nb-dashboard-stats {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-bottom: var(--border);
+}
+
+.nb-dashboard-stat-cell {
+  padding: 24px;
+  background: var(--white);
+  border-right: var(--border);
+  min-width: 0;
+}
+
+.nb-dashboard-stat-cell:last-child {
+  border-right: none;
+}
+
+.nb-dashboard-two-col {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: var(--border);
+}
+
+.nb-dashboard-panel {
+  min-width: 0;
+}
+
+.nb-dashboard-panel--divider-right {
+  border-right: var(--border);
+}
+
+.nb-dashboard-tags-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.nb-dashboard-tags-row .nb-dashboard-panel {
+  border-bottom: var(--border);
+}
+
+.nb-dashboard-chip-area {
+  padding: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 /* ─── Hero Bar ─── */
 .nb-hero-bar {
   background: var(--sage-light);
@@ -1650,6 +1698,45 @@ h1, h2, h3, h4, h5, h6 {
   .nb-post-content {
     padding: 20px;
   }
+
+  .nb-dashboard-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .nb-dashboard-stat-cell {
+    border-right: none;
+    border-bottom: var(--border-2);
+  }
+
+  .nb-dashboard-stat-cell:last-child {
+    border-bottom: none;
+  }
+
+  .nb-dashboard-two-col {
+    grid-template-columns: 1fr;
+  }
+
+  .nb-dashboard-panel--divider-right {
+    border-right: none;
+    border-bottom: var(--border);
+  }
+
+  .nb-dashboard-two-col > .nb-dashboard-panel:last-child {
+    border-bottom: none;
+  }
+
+  .nb-dashboard-tags-row {
+    grid-template-columns: 1fr;
+  }
+
+  .nb-dashboard-tags-row .nb-dashboard-panel--divider-right {
+    border-right: none;
+    border-bottom: var(--border);
+  }
+
+  .nb-dashboard-tags-row > .nb-dashboard-panel:last-child {
+    border-bottom: none;
+  }
 }
 
 @media (max-width: 600px) {
@@ -1669,5 +1756,13 @@ h1, h2, h3, h4, h5, h6 {
 
   .nb-post-header-title {
     font-size: 22px;
+  }
+
+  .nb-dashboard-stat-cell {
+    padding: 18px 20px;
+  }
+
+  .nb-dashboard-stat-cell .nb-stat-value {
+    font-size: 28px;
   }
 }


### PR DESCRIPTION
## Summary

Dashboard KPIs and two-column blocks used fixed 5- and 2-column grids with no breakpoints. This adds responsive layout aligned with the existing 900px / 600px header breakpoints.

## Behavior

- **>900px:** unchanged visual structure (5 stat tiles, 2+2 content layout).
- **≤900px:** stats and each dashboard section stack to a single column with adjusted borders.
- **≤600px:** slightly smaller stat numbers and padding.

## Linear

[TYS-184](https://linear.app/tystar/issue/TYS-184/dashboard-responsive-stats-row-content-grids)

Closes #65

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved Dashboard layout structure with enhanced mobile responsiveness for better experience across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->