### PR TITLE
style(frontend): page edge gutters, copy padding, centered dashboard stats

### DIFF
--- a/frontend/src/pages/CommentList.jsx
+++ b/frontend/src/pages/CommentList.jsx
@@ -51,7 +51,7 @@ export default function CommentList() {
 
   if (fetchError) return (
     <div className="nb-layout-full">
-      <div className="nb-error" style={{ padding: "40px 32px" }}>
+      <div className="nb-error" style={{ padding: "40px var(--nb-copy-pad-x)" }}>
         Failed to load comments. Please refresh the page.
       </div>
     </div>
@@ -77,7 +77,7 @@ export default function CommentList() {
 
       {/* Comment rows */}
       {items.length === 0 && (
-        <div style={{ padding: "40px 32px", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
+        <div style={{ padding: "40px var(--nb-copy-pad-x)", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
           No comments yet.
         </div>
       )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -131,7 +131,7 @@ export default function Dashboard() {
           </div>
           <div className="nb-card-body">
             {data.latest_posts.length === 0 && (
-              <div style={{ padding: "20px 20px", fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No posts yet.</div>
+              <div style={{ padding: "20px var(--nb-copy-pad-x)", fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No posts yet.</div>
             )}
             {data.latest_posts.map((post) => (
               <div key={post.id} className="nb-list-item">
@@ -156,7 +156,7 @@ export default function Dashboard() {
           </div>
           <div className="nb-card-body">
             {data.most_commented_posts.length === 0 && (
-              <div style={{ padding: "20px 20px", fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No posts yet.</div>
+              <div style={{ padding: "20px var(--nb-copy-pad-x)", fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No posts yet.</div>
             )}
             {data.most_commented_posts.map((post) => (
               <div key={post.id} className="nb-list-item">
@@ -184,7 +184,7 @@ export default function Dashboard() {
           </div>
           <div className="nb-card-body">
             {(data.most_liked_posts ?? []).length === 0 && (
-              <div style={{ padding: "20px 20px", fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No comment likes yet.</div>
+              <div style={{ padding: "20px var(--nb-copy-pad-x)", fontFamily: "'Space Mono', monospace", fontSize: "11px", opacity: 0.5 }}>No comment likes yet.</div>
             )}
             {(data.most_liked_posts ?? []).map((post) => (
               <div key={post.id} className="nb-list-item">

--- a/frontend/src/pages/PostDetail.jsx
+++ b/frontend/src/pages/PostDetail.jsx
@@ -415,7 +415,7 @@ export default function PostDetail() {
     <div className="nb-post-detail">
 
       {/* Breadcrumb bar */}
-      <div style={{ borderBottom: "var(--border)", padding: "10px 32px", background: "var(--bg)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      <div style={{ borderBottom: "var(--border)", padding: "10px var(--nb-copy-pad-x)", background: "var(--bg)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <nav aria-label="breadcrumb">
           <ol className="breadcrumb mb-0">
             <li className="breadcrumb-item"><Link to="/posts">Posts</Link></li>
@@ -472,7 +472,7 @@ export default function PostDetail() {
 
       {/* Edit form */}
       {editingPost && (
-        <div style={{ padding: "28px 32px", borderBottom: "var(--border)", background: "var(--white)" }}>
+        <div style={{ padding: "28px var(--nb-copy-pad-x)", borderBottom: "var(--border)", background: "var(--white)" }}>
           <form onSubmit={handlePostUpdate}>
             <div className="nb-field">
               <label>Title</label>
@@ -569,7 +569,7 @@ export default function PostDetail() {
           </span>
         </div>
 
-        <div style={{ padding: "24px 32px", background: "var(--bg)" }}>
+        <div style={{ padding: "24px var(--nb-copy-pad-x)", background: "var(--bg)" }}>
           {user ? (
             <form onSubmit={handleCreateComment} style={{ marginBottom: "24px" }}>
               <div className="nb-field">

--- a/frontend/src/pages/PostList.jsx
+++ b/frontend/src/pages/PostList.jsx
@@ -186,7 +186,7 @@ export default function PostList() {
   if (fetchError) return (
     <div className="nb-layout">
       <main className="nb-main">
-        <div className="nb-error" style={{ padding: "40px 32px" }}>
+        <div className="nb-error" style={{ padding: "40px var(--nb-copy-pad-x)" }}>
           Failed to load posts. Please refresh the page.
         </div>
       </main>
@@ -219,7 +219,7 @@ export default function PostList() {
 
         {/* New Post toggle */}
         {user && (
-          <div style={{ borderBottom: "2px solid var(--black)", padding: "10px 32px", background: "var(--bg)", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div style={{ borderBottom: "2px solid var(--black)", padding: "10px var(--nb-copy-pad-x)", background: "var(--bg)", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
             <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em" }}>
               {showCreate ? "New Post Form" : "Share your knowledge"}
             </span>
@@ -235,7 +235,7 @@ export default function PostList() {
 
         {/* Create post form */}
         {user && showCreate && (
-          <div style={{ borderBottom: "var(--border)", background: "var(--white)", padding: "24px 32px" }}>
+          <div style={{ borderBottom: "var(--border)", background: "var(--white)", padding: "24px var(--nb-copy-pad-x)" }}>
             <form onSubmit={handleCreatePost}>
               <div className="nb-field">
                 <label>Post Title</label>
@@ -302,7 +302,7 @@ export default function PostList() {
 
         {/* Post rows */}
         {items !== null && listItems.length === 0 && (
-          <div style={{ padding: "40px 32px", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
+          <div style={{ padding: "40px var(--nb-copy-pad-x)", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
             No posts yet.
           </div>
         )}

--- a/frontend/src/pages/TagDetail.jsx
+++ b/frontend/src/pages/TagDetail.jsx
@@ -80,7 +80,7 @@ export default function TagDetail() {
 
       {/* Post rows */}
       {items.length === 0 && (
-        <div style={{ padding: "40px 32px", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
+        <div style={{ padding: "40px var(--nb-copy-pad-x)", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
           No posts with this tag yet.
         </div>
       )}

--- a/frontend/src/pages/TagList.jsx
+++ b/frontend/src/pages/TagList.jsx
@@ -114,7 +114,7 @@ export default function TagList() {
 
       {/* Create tag form */}
       {user && showCreate && (
-        <div style={{ borderBottom: "var(--border)", padding: "20px 32px", background: "var(--white)" }}>
+        <div style={{ borderBottom: "var(--border)", padding: "20px var(--nb-copy-pad-x)", background: "var(--white)" }}>
           <form onSubmit={handleCreateTag}>
             <div style={{ display: "flex", gap: "0", maxWidth: "480px" }}>
               <input
@@ -135,7 +135,7 @@ export default function TagList() {
       )}
 
       {/* Tag grid */}
-      <div style={{ padding: "32px", background: "var(--bg)" }}>
+      <div style={{ padding: "32px var(--nb-copy-pad-x)", background: "var(--bg)" }}>
         {data.results.length === 0 && (
           <div style={{ fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>No tags yet.</div>
         )}

--- a/frontend/src/pages/UserDetail.jsx
+++ b/frontend/src/pages/UserDetail.jsx
@@ -102,7 +102,7 @@ export default function UserDetail() {
           </div>
         </div>
 
-        <div style={{ padding: "16px 24px" }}>
+        <div style={{ padding: "16px var(--nb-copy-pad-x)" }}>
           <Link to="/users" style={{ fontFamily: "'Space Mono', monospace", fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--black)", textDecoration: "underline" }}>
             ← All Users
           </Link>
@@ -117,7 +117,7 @@ export default function UserDetail() {
         </div>
 
         {items.length === 0 && (
-          <div style={{ padding: "40px 32px", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
+          <div style={{ padding: "40px var(--nb-copy-pad-x)", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
             No posts yet.
           </div>
         )}

--- a/frontend/src/pages/UserList.jsx
+++ b/frontend/src/pages/UserList.jsx
@@ -46,7 +46,7 @@ export default function UserList() {
 
   if (fetchError) return (
     <div className="nb-layout-full">
-      <div className="nb-error" style={{ padding: "40px 32px" }}>
+      <div className="nb-error" style={{ padding: "40px var(--nb-copy-pad-x)" }}>
         Failed to load users. Please refresh the page.
       </div>
     </div>
@@ -72,7 +72,7 @@ export default function UserList() {
 
       {/* User rows */}
       {items.length === 0 && (
-        <div style={{ padding: "40px 32px", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
+        <div style={{ padding: "40px var(--nb-copy-pad-x)", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
           No users yet.
         </div>
       )}

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -219,12 +219,12 @@ export default function UserProfile() {
             <div className="nb-section-bar">
               <span className="nb-section-title">Account Settings</span>
             </div>
-            <div style={{ padding: "32px", background: "var(--bg)" }}>
+            <div style={{ padding: "32px var(--nb-copy-pad-x)", background: "var(--bg)" }}>
 
               {/* Change Username */}
               <div className="nb-panel" style={{ marginBottom: "24px" }}>
                 <div className="nb-panel-header">Change Username</div>
-                <div style={{ padding: "24px" }}>
+                <div style={{ padding: "24px var(--nb-copy-pad-x)" }}>
                   <div style={{ fontFamily: "'Space Mono', monospace", fontSize: "12px", marginBottom: "16px", opacity: 0.6 }}>
                     Current: <strong style={{ opacity: 1 }}>{user.username}</strong>
                   </div>
@@ -254,7 +254,7 @@ export default function UserProfile() {
               {/* Change Password */}
               <div className="nb-panel">
                 <div className="nb-panel-header">Change Password</div>
-                <div style={{ padding: "24px" }}>
+                <div style={{ padding: "24px var(--nb-copy-pad-x)" }}>
                   <div style={{ fontFamily: "'Space Mono', monospace", fontSize: "12px", marginBottom: "16px", opacity: 0.6 }}>
                     Choose a strong password with at least 8 characters.
                   </div>
@@ -300,7 +300,7 @@ export default function UserProfile() {
             {postItems !== null && (
               <>
                 {postItems.length === 0 && (
-                  <div style={{ padding: "40px 32px", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
+                  <div style={{ padding: "40px var(--nb-copy-pad-x)", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
                     You haven&apos;t written any posts yet.
                   </div>
                 )}
@@ -360,7 +360,7 @@ export default function UserProfile() {
             {commentItems !== null && (
               <>
                 {commentItems.length === 0 && (
-                  <div style={{ padding: "40px 32px", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
+                  <div style={{ padding: "40px var(--nb-copy-pad-x)", textAlign: "center", fontFamily: "'Space Mono', monospace", fontSize: "13px", opacity: 0.5 }}>
                     You haven&apos;t commented on any posts yet.
                   </div>
                 )}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -2,8 +2,12 @@
 
 /* ─── CSS Variables ─── */
 :root {
+  /* Space from viewport corners to chrome (frame, header, dashboard strip). */
+  --nb-page-edge: clamp(16px, 4vw, 36px);
+  /* Horizontal inset for type in bars, list rows, stat cells, post bodies. */
+  --nb-copy-pad-x: clamp(20px, 3.25vw, 40px);
   /* Centered “frame” for main chrome (was 1400px full-bleed feel on large monitors). */
-  --nb-frame-max-width: min(1080px, calc(100vw - 40px));
+  --nb-frame-max-width: min(1080px, calc(100vw - 2 * var(--nb-page-edge)));
   --black: #0a0a0a;
   --white: #fefefe;
   --bg: #E8E2D8;
@@ -325,8 +329,7 @@ h1, h2, h3, h4, h5, h6 {
   z-index: 100;
 }
 
-/* Full-width bar: brand at viewport left, primary nav viewport-centered, auth viewport-right.
-   (Do not reuse --nb-frame-max-width here — that centers the whole strip and pulls the brand inward.) */
+/* Full-width bar: brand left, nav centered, auth right — inset from viewport via --nb-page-edge. */
 .nb-header-inner {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
@@ -335,6 +338,8 @@ h1, h2, h3, h4, h5, h6 {
   width: 100%;
   max-width: none;
   margin: 0;
+  padding-left: var(--nb-page-edge);
+  padding-right: var(--nb-page-edge);
 }
 
 .nb-brand {
@@ -576,7 +581,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .nb-nav-mobile-list a {
   display: block;
-  padding: 16px 24px;
+  padding: 16px var(--nb-copy-pad-x);
   text-decoration: none;
   color: var(--black);
   font-weight: 700;
@@ -597,7 +602,7 @@ h1, h2, h3, h4, h5, h6 {
   background: var(--green);
   color: var(--bg);
   overflow: hidden;
-  padding: 8px 0;
+  padding: 8px var(--nb-page-edge);
   font-family: 'Space Mono', monospace;
   font-size: 11px;
   letter-spacing: 0.1em;
@@ -666,7 +671,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nb-dashboard-stat-cell {
-  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 24px var(--nb-copy-pad-x);
   background: var(--white);
   border-right: var(--border);
   min-width: 0;
@@ -712,7 +721,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nb-dashboard-chip-area {
-  padding: 20px;
+  padding: 20px var(--nb-copy-pad-x);
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -759,7 +768,7 @@ h1, h2, h3, h4, h5, h6 {
 .nb-hero-bar {
   background: var(--sage-light);
   border-bottom: var(--border);
-  padding: 32px;
+  padding: 32px var(--nb-copy-pad-x);
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 40px;
@@ -796,7 +805,7 @@ h1, h2, h3, h4, h5, h6 {
 .nb-section-bar {
   background: var(--green);
   color: var(--bg);
-  padding: 10px 32px;
+  padding: 10px var(--nb-copy-pad-x);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -886,7 +895,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nb-post-body {
-  padding: 16px 24px;
+  padding: 16px var(--nb-copy-pad-x);
   min-width: 0;
 }
 
@@ -1006,7 +1015,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .nb-sidebar-block {
   border-bottom: var(--border);
-  padding: 22px 24px;
+  padding: 22px var(--nb-copy-pad-x);
 }
 
 .nb-sidebar-head {
@@ -1178,7 +1187,7 @@ h1, h2, h3, h4, h5, h6 {
 .nb-panel-header {
   background: var(--bg);
   border-bottom: var(--border);
-  padding: 12px 20px;
+  padding: 12px var(--nb-copy-pad-x);
   font-family: 'Space Mono', monospace;
   font-size: 12px;
   font-weight: 700;
@@ -1198,7 +1207,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nb-content-area {
-  padding: 32px;
+  padding: 32px var(--nb-copy-pad-x);
 }
 
 /* ─── Auth Pages ─── */
@@ -1207,7 +1216,7 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 40px 20px;
+  padding: 40px var(--nb-page-edge);
   background: var(--bg);
 }
 
@@ -1222,7 +1231,7 @@ h1, h2, h3, h4, h5, h6 {
 .nb-auth-header {
   background: var(--black);
   color: var(--sage);
-  padding: 20px 28px;
+  padding: 20px var(--nb-copy-pad-x);
   font-family: 'Space Mono', monospace;
   font-size: 18px;
   font-weight: 700;
@@ -1231,7 +1240,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nb-auth-body {
-  padding: 28px;
+  padding: 28px var(--nb-copy-pad-x);
 }
 
 .nb-field {
@@ -1391,7 +1400,7 @@ h1, h2, h3, h4, h5, h6 {
 .nb-card-header {
   background: var(--green);
   color: var(--bg);
-  padding: 10px 20px;
+  padding: 10px var(--nb-copy-pad-x);
   border-bottom: var(--border);
   font-family: 'Space Mono', monospace;
   font-size: 11px;
@@ -1406,7 +1415,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .nb-list-item {
   border-bottom: 2px solid var(--bg);
-  padding: 12px 20px;
+  padding: 12px var(--nb-copy-pad-x);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -1629,7 +1638,7 @@ h1, h2, h3, h4, h5, h6 {
 .nb-post-header {
   background: var(--sage-light);
   border-bottom: var(--border);
-  padding: 28px 32px;
+  padding: 28px var(--nb-copy-pad-x);
 }
 
 .nb-post-header-title {
@@ -1642,7 +1651,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nb-post-content {
-  padding: 28px 32px;
+  padding: 28px var(--nb-copy-pad-x);
   background: var(--white);
   border-bottom: var(--border);
 }
@@ -1748,7 +1757,7 @@ h1, h2, h3, h4, h5, h6 {
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  padding: 24px 20px 20px;
+  padding: 24px var(--nb-copy-pad-x) 20px;
   border-bottom: var(--border);
   background: var(--white);
 }
@@ -1864,19 +1873,19 @@ h1, h2, h3, h4, h5, h6 {
 
   .nb-hero-bar {
     gap: 20px;
-    padding: 20px;
+    padding: 20px var(--nb-copy-pad-x);
   }
 
   .nb-content-area {
-    padding: 20px;
+    padding: 20px var(--nb-copy-pad-x);
   }
 
   .nb-post-header {
-    padding: 20px;
+    padding: 20px var(--nb-copy-pad-x);
   }
 
   .nb-post-content {
-    padding: 20px;
+    padding: 20px var(--nb-copy-pad-x);
   }
 
   .nb-dashboard-stats {
@@ -1940,6 +1949,7 @@ h1, h2, h3, h4, h5, h6 {
   .nb-hero-bar {
     grid-template-columns: 1fr;
     gap: 10px;
+    padding: 20px var(--nb-copy-pad-x);
   }
 
   .nb-post-header-title {
@@ -1947,7 +1957,7 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   .nb-dashboard-stat-cell {
-    padding: 18px 20px;
+    padding: 18px var(--nb-copy-pad-x);
   }
 
   .nb-dashboard-stat-cell .nb-stat-value {


### PR DESCRIPTION
## Summary
- Introduce `--nb-page-edge` and `--nb-copy-pad-x` so the framed column, header, ticker, and auth sit farther from the viewport while copy stays comfortably inset.
- Leave the dashboard KPI strip full-bleed (no beige gutters); only the numbers and labels use horizontal padding inside each white cell.
- Center the KPI value and label in each stat cell; page-level blocks use `var(--nb-copy-pad-x)` in inline padding for consistency.

## Test plan
- [x] `uv run pytest`
- [x] `cd frontend && npm run lint && npm test -- --run`
- [ ] Manually spot-check dashboard, posts list, and a post detail on narrow and wide viewports


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized horizontal padding across all pages and components to use responsive CSS variables, replacing hardcoded values with flexible spacing tokens for improved consistency and mobile responsiveness.

* **Refactor**
  * Updated the theme system with new responsive spacing variables that automatically adjust padding based on viewport size for a more adaptive layout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->