### PR TITLE
feat(api): GET /activity/ for header ticker (5 min cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ GET  /api/users/                User list
 GET  /api/users/:username/      User profile + posts
 GET  /api/users/:username/comments/ User's comments
 
-GET  /api/dashboard/            Aggregated site stats
+GET  /api/dashboard/            Aggregated site stats (panels)
+GET  /api/activity/             Recent activity for header ticker
 ```
 
 All list endpoints are paginated (default page size: 50). All write endpoints are rate-limited.

--- a/blog/api/data/router.py
+++ b/blog/api/data/router.py
@@ -30,6 +30,7 @@ from ..constants import AUTHENTICATION_REQUIRED_DETAIL
 from ..throttling import READ_THROTTLES, WRITE_THROTTLES
 from ..utils import request_data_or_error as _request_data_or_error
 from .schemas import (
+    ActivityResponse,
     DashboardResponse,
     NotFoundResponse,
     PaginatedCommentsResponse,
@@ -69,7 +70,16 @@ def _post_detail_queryset():
     )
 
 
-# ── Dashboard ────────────────────────────────────────────────────────────────
+# ── Dashboard & activity (ticker) ───────────────────────────────────────────
+
+
+@router.api_operation(["GET", "HEAD"], "/activity/", response=ActivityResponse)
+def activity(request: HttpRequest):
+    data = cache.get(api_views._ACTIVITY_CACHE_KEY)
+    if data is None:
+        data = api_views.build_activity_payload()
+        cache.set(api_views._ACTIVITY_CACHE_KEY, data, api_views._ACTIVITY_CACHE_TTL)
+    return JsonResponse(data, status=200)
 
 
 @router.api_operation(["GET", "HEAD"], "/dashboard/", response=DashboardResponse)

--- a/blog/api/data/schemas.py
+++ b/blog/api/data/schemas.py
@@ -87,7 +87,7 @@ class DashboardStatsResponse(Schema):
     new_posts_7d: int
 
 
-class DashboardActivityResponse(Schema):
+class ActivityResponse(Schema):
     """Recent public activity for the header ticker (nullable when no data)."""
 
     latest_post_title: str | None = None
@@ -101,7 +101,6 @@ class DashboardActivityResponse(Schema):
 
 class DashboardResponse(Schema):
     stats: DashboardStatsResponse
-    activity: DashboardActivityResponse
     latest_posts: list[PostSummaryResponse]
     most_commented_posts: list[PostSummaryResponse]
     most_liked_posts: list[PostSummaryResponse]

--- a/blog/api_views.py
+++ b/blog/api_views.py
@@ -108,7 +108,14 @@ _ACTIVITY_CACHE_TTL = 300  # seconds — header ticker; short DB/query load
 def build_activity_payload():
     """Recent public activity for the navbar ticker (no caching); used by /api/activity/."""
     published = Post.objects.filter(status=Post.Status.PUBLISHED)
-    latest_post = published.order_by("-published_at", "-created_at").defer("body").first()
+    # Effective sort key avoids Postgres NULLS FIRST on -published_at ranking unset
+    # published posts ahead of newer-timestamp posts that have a real published_at.
+    latest_post = (
+        published.annotate(_activity_pub_at=Coalesce("published_at", "created_at"))
+        .order_by("-_activity_pub_at")
+        .defer("body")
+        .first()
+    )
     latest_comment = (
         Comment.objects.filter(post__status=Post.Status.PUBLISHED)
         .select_related("author", "post")

--- a/blog/api_views.py
+++ b/blog/api_views.py
@@ -101,20 +101,13 @@ def can_access_comment(user, comment):
 _DASHBOARD_CACHE_KEY = "dashboard_data"
 _DASHBOARD_CACHE_TTL = 60  # seconds
 
+_ACTIVITY_CACHE_KEY = "activity_data"
+_ACTIVITY_CACHE_TTL = 300  # seconds — header ticker; short DB/query load
 
-def build_dashboard_payload():
-    """Assemble dashboard JSON (no caching); used by Ninja read routes."""
+
+def build_activity_payload():
+    """Recent public activity for the navbar ticker (no caching); used by /api/activity/."""
     published = Post.objects.filter(status=Post.Status.PUBLISHED)
-    total_posts = published.count()
-    total_comments = Comment.objects.filter(post__status=Post.Status.PUBLISHED).count()
-    total_authors = User.objects.filter(posts__status=Post.Status.PUBLISHED).distinct().count()
-    active_tags = Tag.objects.filter(posts__status=Post.Status.PUBLISHED).distinct().count()
-    cutoff_7d = timezone.now() - timedelta(days=7)
-    new_posts_7d = published.filter(
-        Q(published_at__gte=cutoff_7d)
-        | (Q(published_at__isnull=True) & Q(created_at__gte=cutoff_7d))
-    ).count()
-
     latest_post = published.order_by("-published_at", "-created_at").defer("body").first()
     latest_comment = (
         Comment.objects.filter(post__status=Post.Status.PUBLISHED)
@@ -143,6 +136,21 @@ def build_dashboard_payload():
     if latest_user:
         activity["latest_user_username"] = latest_user.username
         activity["latest_user_joined_at"] = latest_user.date_joined
+    return activity
+
+
+def build_dashboard_payload():
+    """Assemble dashboard JSON (no caching); used by Ninja read routes."""
+    published = Post.objects.filter(status=Post.Status.PUBLISHED)
+    total_posts = published.count()
+    total_comments = Comment.objects.filter(post__status=Post.Status.PUBLISHED).count()
+    total_authors = User.objects.filter(posts__status=Post.Status.PUBLISHED).distinct().count()
+    active_tags = Tag.objects.filter(posts__status=Post.Status.PUBLISHED).distinct().count()
+    cutoff_7d = timezone.now() - timedelta(days=7)
+    new_posts_7d = published.filter(
+        Q(published_at__gte=cutoff_7d)
+        | (Q(published_at__isnull=True) & Q(created_at__gte=cutoff_7d))
+    ).count()
 
     return {
         "stats": {
@@ -152,7 +160,6 @@ def build_dashboard_payload():
             "active_tags": active_tags,
             "new_posts_7d": new_posts_7d,
         },
-        "activity": activity,
         "latest_posts": PostSerializer(
             _published_posts_list_qs().order_by("-created_at")[:10],
             many=True,

--- a/blog/management/commands/silk_profiler.py
+++ b/blog/management/commands/silk_profiler.py
@@ -35,6 +35,7 @@ def _build_endpoints(post_slug, tag_slug, username, comment_id):
     return [
         # ── Public reads ──────────────────────────────────────────────
         ("GET", "/api/dashboard/", None, "Dashboard (aggregated stats)"),
+        ("GET", "/api/activity/", None, "Activity ticker (header)"),
         ("GET", "/api/posts/", None, "Post list (page 1)"),
         ("GET", "/api/posts/?page=2", None, "Post list (page 2)"),
         ("GET", f"/api/posts/{post_slug}/", None, "Post detail + comments"),

--- a/docs/developers/backend.md
+++ b/docs/developers/backend.md
@@ -57,6 +57,7 @@ Typical API flow:
 ### Public read endpoints
 
 - `GET /api/dashboard/`
+- `GET /api/activity/`
 - `GET /api/comments/`
 - `GET /api/posts/`
 - `GET /api/posts/<slug>/`

--- a/docs/developers/backend.md
+++ b/docs/developers/backend.md
@@ -57,7 +57,7 @@ Typical API flow:
 ### Public read endpoints
 
 - `GET /api/dashboard/`
-- `GET /api/activity/`
+- `GET /api/activity/` (also `HEAD /api/activity/`)
 - `GET /api/comments/`
 - `GET /api/posts/`
 - `GET /api/posts/<slug>/`

--- a/frontend/src/App.mobile.test.jsx
+++ b/frontend/src/App.mobile.test.jsx
@@ -9,6 +9,7 @@ import { mockMobileViewport, mockDesktopViewport } from "./test/viewport";
 vi.mock("./api/client", () => import("./test/mocks/client.js"));
 
 import {
+  fetchActivity,
   fetchCurrentUser,
   fetchDashboard,
   fetchPosts,
@@ -37,10 +38,11 @@ const DASHBOARD_PAYLOAD = {
   most_liked_posts: [],
   most_used_tags: [{ id: 1, slug: "django", name: "django", post_count: 2 }],
   top_authors: [{ id: 1, username: "alice", post_count: 2 }],
-  activity: {
-    latest_post_title: "Alpha",
-    latest_post_at: "2026-01-01T12:00:00Z",
-  },
+};
+
+const ACTIVITY_PAYLOAD = {
+  latest_post_title: "Alpha",
+  latest_post_at: "2026-01-01T12:00:00Z",
 };
 
 function renderAppAt(path) {
@@ -59,6 +61,7 @@ describe("App mobile layout (narrow viewport)", () => {
       profile: { role: "user" },
     });
     vi.mocked(fetchDashboard).mockResolvedValue(DASHBOARD_PAYLOAD);
+    vi.mocked(fetchActivity).mockResolvedValue(ACTIVITY_PAYLOAD);
     vi.mocked(fetchPosts).mockResolvedValue({
       results: [
         {

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -43,6 +43,7 @@ api.interceptors.request.use(async (config) => {
 });
 
 export const fetchDashboard = () => api.get("/dashboard/").then((r) => r.data);
+export const fetchActivity = () => api.get("/activity/").then((r) => r.data);
 export const fetchComments = (page = 1) => api.get(`/comments/?page=${page}`).then((r) => r.data);
 
 export const fetchPosts = (page = 1) => api.get(`/posts/?page=${page}`).then((r) => r.data);

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
-import { fetchDashboard } from "../api/client";
+import { fetchActivity } from "../api/client";
 import { useEffect, useRef, useState } from "react";
 import { useNarrowHeader } from "../hooks/useNarrowHeader";
 
@@ -28,10 +28,10 @@ function fmtTickerWhen(iso) {
   });
 }
 
-/** Build scrolling headline lines from dashboard `activity` (news-style). */
-function buildTickerLinesFromDashboard(data) {
+/** Build scrolling headline lines from `/api/activity/` payload (news-style). */
+function buildTickerLinesFromActivity(data) {
   if (!data || data.failed) return null;
-  const a = data.activity ?? {};
+  const a = data;
   const lines = [];
   if (a.latest_post_title && a.latest_post_at) {
     const title = truncTickerLabel(a.latest_post_title, 48);
@@ -69,7 +69,7 @@ export default function Navbar() {
   const prevNarrowRef = useRef(null);
 
   useEffect(() => {
-    fetchDashboard()
+    fetchActivity()
       .then((data) => setTickerSource(data ?? { failed: true }))
       .catch(() => setTickerSource({ failed: true }));
   }, []);
@@ -115,7 +115,7 @@ export default function Navbar() {
     return false;
   };
 
-  const tickerItems = buildTickerLinesFromDashboard(tickerSource);
+  const tickerItems = buildTickerLinesFromActivity(tickerSource);
 
   const primaryNavList = (variant) => (
     <ul className={variant === "desktop" ? "nb-nav" : "nb-nav-mobile-list"}>

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation, useSearchParams } from "react-router-dom";
 import { vi } from "vitest";
-import { fetchDashboard } from "../api/client";
+import { fetchActivity } from "../api/client";
 import { mockDesktopViewport, mockMobileViewport } from "../test/viewport";
 vi.mock("../api/client", () => import("../test/mocks/client.js"));
 
@@ -36,39 +36,21 @@ describe("Navbar", () => {
   beforeEach(() => {
     mockDesktopViewport();
     authStore.user = { username: "alice", profile: { role: "user" } };
-    vi.mocked(fetchDashboard).mockResolvedValue({
-      stats: {
-        total_posts: 1,
-        authors: 1,
-        active_tags: 1,
-        comments: 0,
-        new_posts_7d: 0,
-      },
-      activity: {
-        latest_post_title: "Hello",
-        latest_post_at: "2026-04-01T12:00:00.000Z",
-      },
+    vi.mocked(fetchActivity).mockResolvedValue({
+      latest_post_title: "Hello",
+      latest_post_at: "2026-04-01T12:00:00.000Z",
     });
   });
 
-  it("ticker shows news-style lines from dashboard activity", async () => {
-    vi.mocked(fetchDashboard).mockResolvedValue({
-      stats: {
-        total_posts: 2,
-        authors: 1,
-        active_tags: 1,
-        comments: 1,
-        new_posts_7d: 1,
-      },
-      activity: {
-        latest_post_title: "Alpha Post",
-        latest_post_at: "2026-04-10T08:00:00.000Z",
-        latest_comment_author: "bob",
-        latest_comment_at: "2026-04-11T09:00:00.000Z",
-        latest_comment_post_title: "Beta Thread",
-        latest_user_username: "carol",
-        latest_user_joined_at: "2026-04-12T10:00:00.000Z",
-      },
+  it("ticker shows news-style lines from activity endpoint", async () => {
+    vi.mocked(fetchActivity).mockResolvedValue({
+      latest_post_title: "Alpha Post",
+      latest_post_at: "2026-04-10T08:00:00.000Z",
+      latest_comment_author: "bob",
+      latest_comment_at: "2026-04-11T09:00:00.000Z",
+      latest_comment_post_title: "Beta Thread",
+      latest_user_username: "carol",
+      latest_user_joined_at: "2026-04-12T10:00:00.000Z",
     });
     render(
       <MemoryRouter>
@@ -102,7 +84,7 @@ describe("Navbar", () => {
         <Navbar />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(fetchActivity)).toHaveBeenCalled());
 
     const nav = screen.getByRole("navigation", { name: "Primary" });
     expect(within(nav).getByRole("link", { name: "Posts" })).toHaveAttribute("href", "/posts");
@@ -129,7 +111,7 @@ describe("Navbar", () => {
       </MemoryRouter>,
     );
     expect(screen.queryByRole("link", { name: "+ New Post" })).toBeNull();
-    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(fetchActivity)).toHaveBeenCalled());
   });
 
   it("navigates to /posts with openCreate when + New Post is used from another page", async () => {
@@ -197,7 +179,7 @@ describe("Navbar", () => {
         <Navbar />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(fetchActivity)).toHaveBeenCalled());
     expect(screen.queryByRole("navigation", { name: "Primary" })).toBeNull();
     expect(
       screen.getByRole("button", { name: "Open navigation menu" }),
@@ -212,7 +194,7 @@ describe("Navbar", () => {
         <Navbar />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(fetchActivity)).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
     expect(await screen.findByRole("link", { name: "Posts" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Tags" })).toBeInTheDocument();
@@ -227,7 +209,7 @@ describe("Navbar", () => {
         <Navbar />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(vi.mocked(fetchDashboard)).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(fetchActivity)).toHaveBeenCalled());
     await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
     expect(await screen.findByRole("link", { name: "Posts" })).toBeInTheDocument();
     await user.keyboard("{Escape}");

--- a/frontend/src/test/mocks/client.js
+++ b/frontend/src/test/mocks/client.js
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 export const fetchDashboard = vi.fn();
+export const fetchActivity = vi.fn();
 export const fetchComments = vi.fn();
 
 export const fetchPosts = vi.fn();

--- a/tests/robot/api/users_api.robot
+++ b/tests/robot/api/users_api.robot
@@ -54,8 +54,14 @@ Dashboard Stats Are Present And Numeric
 Dashboard Returns Latest Posts And Tags
     ${resp}=    GET On Session    api    /api/dashboard/
     ${json}=    Set Variable    ${resp.json()}
-    Dictionary Should Contain Key    ${json}    activity
     Dictionary Should Contain Key    ${json}    latest_posts
     Dictionary Should Contain Key    ${json}    most_liked_posts
     Dictionary Should Contain Key    ${json}    most_used_tags
     Dictionary Should Contain Key    ${json}    top_authors
+
+Activity Endpoint Returns Ticker Fields
+    ${resp}=    GET On Session    api    /api/activity/
+    Should Be Equal As Integers    ${resp.status_code}    200
+    ${json}=    Set Variable    ${resp.json()}
+    Dictionary Should Contain Key    ${json}    latest_post_title
+    Dictionary Should Contain Key    ${json}    latest_user_joined_at

--- a/tests/security/security_smoke.py
+++ b/tests/security/security_smoke.py
@@ -195,6 +195,7 @@ def check_content_type_enforcement(base_url: str) -> CheckResult:
     endpoints = [
         "/api/posts/",
         "/api/dashboard/",
+        "/api/activity/",
         "/api/tags/",
     ]
     non_json = []

--- a/tests/unit/test_ninja_read_preview.py
+++ b/tests/unit/test_ninja_read_preview.py
@@ -15,10 +15,16 @@ class TestNinjaRead:
         data = resp.json()
         assert resp.status_code == 200
         assert "stats" in data
-        assert "activity" in data
         assert "latest_posts" in data
         assert "most_liked_posts" in data
         assert "most_used_tags" in data
+
+    def test_activity_returns_ticker_shape(self, api_client):
+        resp = api_client.get("/api/activity/")
+        data = resp.json()
+        assert resp.status_code == 200
+        assert "latest_post_title" in data
+        assert "latest_user_joined_at" in data
 
     def test_post_list_is_paginated(self, api_client, post):
         resp = api_client.get("/api/posts/")

--- a/tests/unit/test_ninja_schema_contract.py
+++ b/tests/unit/test_ninja_schema_contract.py
@@ -12,6 +12,7 @@ from django.test import RequestFactory
 
 from blog.api.auth.schemas import CurrentUserResponse
 from blog.api.data.schemas import (
+    ActivityResponse,
     CommentListItemResponse,
     CommentResponse,
     DashboardResponse,
@@ -159,6 +160,11 @@ class TestDashboardSchemaContract:
         data = api_views.build_dashboard_payload()
         validated = DashboardResponse(**data)
         assert validated.stats.total_posts >= 1
+
+    def test_activity_payload_validates(self, post, comment):
+        data = api_views.build_activity_payload()
+        validated = ActivityResponse(**data)
+        assert validated.latest_post_title == post.title
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_views_activity.py
+++ b/tests/unit/test_views_activity.py
@@ -1,11 +1,23 @@
 """Unit tests for GET /api/activity/ (header ticker payload)."""
 
+from datetime import timedelta
+
 import pytest
+from django.core.cache import cache
+from django.utils import timezone
+
+from blog import api_views
+from blog.models import Post
 
 
 @pytest.mark.django_db
 class TestActivityView:
     """Tests for GET /api/activity/."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_activity_cache(self):
+        cache.delete(api_views._ACTIVITY_CACHE_KEY)
+        yield
 
     def test_returns_200_for_anonymous(self, api_client):
         resp = api_client.get("/api/activity/")
@@ -32,8 +44,31 @@ class TestActivityView:
         assert data["latest_post_title"] == post.title
         assert data["latest_comment_author"] == comment.author.username
 
-    def test_empty_database_nullable_fields(self, api_client, db):
+    def test_empty_database_nullable_fields(self, api_client):
         data = api_client.get("/api/activity/").json()
         assert data["latest_post_title"] is None
         assert data["latest_comment_at"] is None
         assert data["latest_user_username"] is None
+
+    def test_latest_post_orders_by_effective_publish_time(self, api_client, user):
+        """NULL published_at must not outrank a newer real publication via NULLS FIRST."""
+        now = timezone.now()
+        Post.objects.create(
+            title="Older explicit publish",
+            slug="older-explicit",
+            author=user,
+            body="a",
+            status=Post.Status.PUBLISHED,
+            published_at=now - timedelta(days=2),
+        )
+        null_pub = Post.objects.create(
+            title="Null publish newer created",
+            slug="null-pub-newer-created",
+            author=user,
+            body="b",
+            status=Post.Status.PUBLISHED,
+            published_at=None,
+        )
+        Post.objects.filter(pk=null_pub.pk).update(created_at=now - timedelta(days=10))
+        data = api_client.get("/api/activity/").json()
+        assert data["latest_post_title"] == "Older explicit publish"

--- a/tests/unit/test_views_activity.py
+++ b/tests/unit/test_views_activity.py
@@ -1,0 +1,39 @@
+"""Unit tests for GET /api/activity/ (header ticker payload)."""
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestActivityView:
+    """Tests for GET /api/activity/."""
+
+    def test_returns_200_for_anonymous(self, api_client):
+        resp = api_client.get("/api/activity/")
+        assert resp.status_code == 200
+
+    def test_head_returns_200(self, api_client):
+        resp = api_client.head("/api/activity/")
+        assert resp.status_code == 200
+
+    def test_response_is_ticker_fields_only(self, api_client):
+        data = api_client.get("/api/activity/").json()
+        assert set(data.keys()) == {
+            "latest_post_title",
+            "latest_post_at",
+            "latest_comment_author",
+            "latest_comment_at",
+            "latest_comment_post_title",
+            "latest_user_username",
+            "latest_user_joined_at",
+        }
+
+    def test_reflects_post_and_comment(self, api_client, post, comment):
+        data = api_client.get("/api/activity/").json()
+        assert data["latest_post_title"] == post.title
+        assert data["latest_comment_author"] == comment.author.username
+
+    def test_empty_database_nullable_fields(self, api_client, db):
+        data = api_client.get("/api/activity/").json()
+        assert data["latest_post_title"] is None
+        assert data["latest_comment_at"] is None
+        assert data["latest_user_username"] is None

--- a/tests/unit/test_views_dashboard.py
+++ b/tests/unit/test_views_dashboard.py
@@ -27,26 +27,11 @@ class TestDashboardView:
         """Response includes all expected top-level sections."""
         data = api_client.get("/api/dashboard/").json()
         assert "stats" in data
-        assert "activity" in data
         assert "latest_posts" in data
         assert "most_commented_posts" in data
         assert "most_liked_posts" in data
         assert "most_used_tags" in data
         assert "top_authors" in data
-
-    def test_activity_has_expected_fields(self, api_client):
-        """activity block exposes ticker-friendly nullable fields."""
-        activity = api_client.get("/api/dashboard/").json()["activity"]
-        for key in (
-            "latest_post_title",
-            "latest_post_at",
-            "latest_comment_author",
-            "latest_comment_at",
-            "latest_comment_post_title",
-            "latest_user_username",
-            "latest_user_joined_at",
-        ):
-            assert key in activity
 
     def test_stats_contains_expected_fields(self, api_client):
         """stats section exposes all expected counters."""
@@ -64,7 +49,7 @@ class TestDashboardView:
         assert stats["total_posts"] >= 1
         assert stats["new_posts_7d"] >= 1
         assert stats["comments"] >= 1
-        act = data["activity"]
+        act = api_client.get("/api/activity/").json()
         assert act["latest_post_title"] == post.title
         assert act["latest_comment_author"] == comment.author.username
 
@@ -117,7 +102,7 @@ class TestDashboardView:
         assert stats["authors"] == 0
         assert stats["active_tags"] == 0
         assert stats["new_posts_7d"] == 0
-        act = data["activity"]
+        act = api_client.get("/api/activity/").json()
         assert act["latest_post_title"] is None
         assert act["latest_comment_at"] is None
         assert act["latest_user_username"] is None

--- a/tests/unit/test_views_dashboard.py
+++ b/tests/unit/test_views_dashboard.py
@@ -32,6 +32,7 @@ class TestDashboardView:
         assert "most_liked_posts" in data
         assert "most_used_tags" in data
         assert "top_authors" in data
+        assert "activity" not in data
 
     def test_stats_contains_expected_fields(self, api_client):
         """stats section exposes all expected counters."""
@@ -49,6 +50,7 @@ class TestDashboardView:
         assert stats["total_posts"] >= 1
         assert stats["new_posts_7d"] >= 1
         assert stats["comments"] >= 1
+        assert "activity" not in data
         act = api_client.get("/api/activity/").json()
         assert act["latest_post_title"] == post.title
         assert act["latest_comment_author"] == comment.author.username
@@ -102,6 +104,7 @@ class TestDashboardView:
         assert stats["authors"] == 0
         assert stats["active_tags"] == 0
         assert stats["new_posts_7d"] == 0
+        assert "activity" not in data
         act = api_client.get("/api/activity/").json()
         assert act["latest_post_title"] is None
         assert act["latest_comment_at"] is None


### PR DESCRIPTION
## Summary

- Adds **`GET/HEAD /api/activity/`** returning the former ticker `activity` object, with **300s** Django cache.
- Removes **`activity`** from **`GET /api/dashboard/`**; shared builder **`build_activity_payload()`** in `blog/api_views.py`.
- **Navbar** loads the ticker via **`fetchActivity()`** instead of the full dashboard payload.

## Linked issues

Closes #76

## Verification

- `uv run pytest` (full suite)
- `uv run ruff check` / `ruff format`
- `cd frontend && npm run lint && npm test`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added a dedicated `/api/activity/` endpoint for retrieving recent activity ticker data (latest posts, comments, and users).

**Documentation**
* Updated API documentation to reflect the new activity endpoint and refined dashboard endpoint description.

**Refactor**
* Separated activity data fetching from the dashboard endpoint; activity now uses its own dedicated API call for improved modularity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->