### PR TITLE
test(robot): harden Ninja API contract coverage (TYS-178)

### DIFF
--- a/tests/robot/api/comments_api.robot
+++ b/tests/robot/api/comments_api.robot
@@ -50,3 +50,32 @@ Can Create Comment On Post As Authenticated User
         ${resp}=    POST On Session    api    /api/posts/${slug}/comments/    json=${body}    headers=${headers}
         Should Be Equal As Integers    ${resp.status_code}    201
     END
+
+Can Vote Like On Comment As Authenticated User
+    Login Test User
+    ${posts_resp}=    GET On Session    api    /api/posts/
+    ${posts_json}=    Set Variable    ${posts_resp.json()}
+    ${results}=    Get From Dictionary    ${posts_json}    results
+    ${length}=    Get Length    ${results}
+    IF    ${length} > 0
+        ${post}=    Get From List    ${results}    0
+        ${slug}=    Get From Dictionary    ${post}    slug
+        ${token}=    Get CSRF Token
+        ${headers}=    Create Dictionary    X-CSRFToken=${token}
+        ${body}=    Create Dictionary    body=Robot vote target comment
+        ${create}=    POST On Session    api    /api/posts/${slug}/comments/    json=${body}    headers=${headers}
+        Should Be Equal As Integers    ${create.status_code}    201
+        ${created}=    Set Variable    ${create.json()}
+        ${cid}=    Get From Dictionary    ${created}    id
+        ${vote_headers}=    Create Dictionary    X-CSRFToken=${token}
+        ${vote_body}=    Create Dictionary    vote=like
+        ${vote_resp}=    POST On Session
+        ...    api
+        ...    /api/comments/${cid}/vote/
+        ...    json=${vote_body}
+        ...    headers=${vote_headers}
+        Should Be Equal As Integers    ${vote_resp.status_code}    200
+        ${vj}=    Set Variable    ${vote_resp.json()}
+        Dictionary Should Contain Key    ${vj}    likes
+        Dictionary Should Contain Key    ${vj}    dislikes
+    END

--- a/tests/robot/api/users_api.robot
+++ b/tests/robot/api/users_api.robot
@@ -55,6 +55,7 @@ Dashboard Returns Latest Posts And Tags
     ${resp}=    GET On Session    api    /api/dashboard/
     ${json}=    Set Variable    ${resp.json()}
     Dictionary Should Contain Key    ${json}    latest_posts
+    Dictionary Should Contain Key    ${json}    most_commented_posts
     Dictionary Should Contain Key    ${json}    most_liked_posts
     Dictionary Should Contain Key    ${json}    most_used_tags
     Dictionary Should Contain Key    ${json}    top_authors
@@ -64,4 +65,9 @@ Activity Endpoint Returns Ticker Fields
     Should Be Equal As Integers    ${resp.status_code}    200
     ${json}=    Set Variable    ${resp.json()}
     Dictionary Should Contain Key    ${json}    latest_post_title
+    Dictionary Should Contain Key    ${json}    latest_post_at
+    Dictionary Should Contain Key    ${json}    latest_comment_author
+    Dictionary Should Contain Key    ${json}    latest_comment_at
+    Dictionary Should Contain Key    ${json}    latest_comment_post_title
+    Dictionary Should Contain Key    ${json}    latest_user_username
     Dictionary Should Contain Key    ${json}    latest_user_joined_at


### PR DESCRIPTION
## Summary

Follow-up hardening for [TYS-178](https://linear.app/tystar/issue/TYS-178/migrate-frontend-tests-and-robot-coverage-for-the-ninja-api) — Robot API asserts now mirror the Ninja dashboard schema, header ticker (`/api/activity/`), and comment vote mutation used by the React client.

## Changes

- `tests/robot/api/users_api.robot`: require `most_commented_posts`; assert full activity ticker keys (aligned with `ActivityResponse` / Navbar).
- `tests/robot/api/comments_api.robot`: smoke test `POST /api/comments/{id}/vote/` with CSRF; expect serialized comment with `likes` / `dislikes`.

Related tracking: GitHub [#40](https://github.com/tystar86/claude_rest_api/issues/40) (already closed).

## Test plan

- [x] `uv run pytest`
- [x] `cd frontend && npm test`
- [x] `uv run robot --dryrun tests/robot/api/comments_api.robot tests/robot/api/users_api.robot`
- [ ] CI Robot (API/UI) green on merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added API test coverage for comment voting functionality, validating endpoint responses and data structure integrity.
  * Enhanced validation tests for dashboard and activity API endpoints to ensure accurate and complete data delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->