### PR TITLE
feat(frontend): global site footer (TYS-192)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 import Navbar from "./components/Navbar";
+import SiteFooter from "./components/SiteFooter";
 import Dashboard from "./pages/Dashboard";
 import CommentList from "./pages/CommentList";
 import PostList from "./pages/PostList";
@@ -18,20 +19,23 @@ export default function App() {
     <AuthProvider>
       <div className="app-shell">
         <Navbar />
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/comments" element={<CommentList />} />
-          <Route path="/posts" element={<PostList />} />
-          <Route path="/posts/:slug" element={<PostDetail />} />
-          <Route path="/tags" element={<TagList />} />
-          <Route path="/tags/:slug" element={<TagDetail />} />
-          <Route path="/users" element={<UserList />} />
-          <Route path="/users/:username" element={<UserDetail />} />
-          <Route path="/profile" element={<UserProfile />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
-        </Routes>
+        <div className="app-shell-body">
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/comments" element={<CommentList />} />
+            <Route path="/posts" element={<PostList />} />
+            <Route path="/posts/:slug" element={<PostDetail />} />
+            <Route path="/tags" element={<TagList />} />
+            <Route path="/tags/:slug" element={<TagDetail />} />
+            <Route path="/users" element={<UserList />} />
+            <Route path="/users/:username" element={<UserDetail />} />
+            <Route path="/profile" element={<UserProfile />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+          </Routes>
+        </div>
+        <SiteFooter />
       </div>
     </AuthProvider>
   );

--- a/frontend/src/App.mobile.test.jsx
+++ b/frontend/src/App.mobile.test.jsx
@@ -136,6 +136,7 @@ describe("App mobile layout (narrow viewport)", () => {
 
     await waitFor(() => expect(screen.getByText("Hello")).toBeInTheDocument());
     expect(document.querySelector(".app-shell")).not.toBeNull();
+    expect(screen.getByRole("contentinfo")).toHaveTextContent(/created by tystar/i);
     expect(
       screen.getByRole("button", { name: "Open navigation menu" }),
     ).toBeInTheDocument();

--- a/frontend/src/components/SiteFooter.jsx
+++ b/frontend/src/components/SiteFooter.jsx
@@ -1,0 +1,7 @@
+export default function SiteFooter() {
+  return (
+    <footer className="nb-site-footer" aria-label="Site footer">
+      <small className="nb-site-footer-text">Created by tystar · 2026</small>
+    </footer>
+  );
+}

--- a/frontend/src/components/SiteFooter.test.jsx
+++ b/frontend/src/components/SiteFooter.test.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import SiteFooter from "./SiteFooter";
+
+describe("SiteFooter", () => {
+  it("shows attribution and site creation year", () => {
+    render(<SiteFooter />);
+    expect(screen.getByRole("contentinfo", { name: /site footer/i })).toHaveTextContent(
+      "Created by tystar · 2026",
+    );
+  });
+});

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -10,6 +10,8 @@
   --nb-stat-cell-pad-x: clamp(6px, 1.5vw, 14px);
   /* Centered “frame” for main chrome (was 1400px full-bleed feel on large monitors). */
   --nb-frame-max-width: min(1080px, calc(100vw - 2 * var(--nb-page-edge)));
+  /* Reserve space in main-column min-heights so header + content + footer fits the viewport. */
+  --nb-footer-height: 48px;
   --black: #0a0a0a;
   --white: #fefefe;
   --bg: #E8E2D8;
@@ -319,7 +321,34 @@ h1, h2, h3, h4, h5, h6 {
 /* ─── App Shell ─── */
 .app-shell {
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   background: var(--bg);
+}
+
+.app-shell-body {
+  flex: 1 1 auto;
+}
+
+/* ─── Site footer (global) ─── */
+.nb-site-footer {
+  flex-shrink: 0;
+  border-top: var(--border);
+  background: var(--bg);
+  padding: 12px var(--nb-page-edge);
+  text-align: center;
+}
+
+.nb-site-footer-text {
+  display: block;
+  margin: 0;
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--black);
+  opacity: 0.72;
 }
 
 /* ─── Header / Navbar ─── */
@@ -637,7 +666,7 @@ h1, h2, h3, h4, h5, h6 {
   border-left: var(--border);
   border-right: var(--border);
   border-bottom: var(--border);
-  min-height: calc(100vh - 95px);
+  min-height: calc(100vh - 95px - var(--nb-footer-height));
 }
 
 .nb-main {
@@ -651,7 +680,7 @@ h1, h2, h3, h4, h5, h6 {
   border-left: var(--border);
   border-right: var(--border);
   border-bottom: var(--border);
-  min-height: calc(100vh - 95px);
+  min-height: calc(100vh - 95px - var(--nb-footer-height));
 }
 
 /* Dashboard: full-bleed main column (viewport-wide strip under the header). */
@@ -1212,7 +1241,7 @@ h1, h2, h3, h4, h5, h6 {
   border-left: var(--border);
   border-right: var(--border);
   border-bottom: var(--border);
-  min-height: calc(100vh - 95px);
+  min-height: calc(100vh - 95px - var(--nb-footer-height));
   background: var(--bg);
 }
 
@@ -1222,7 +1251,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* ─── Auth Pages ─── */
 .nb-auth-page {
-  min-height: calc(100vh - 95px);
+  min-height: calc(100vh - 95px - var(--nb-footer-height));
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary

Adds a single global footer to the React app shell with fixed copy **Created by tystar · 2026**, semantic `<footer>` landmark, and styles aligned with existing theme tokens. The app shell uses a flex column so the main area still grows; main layout min-heights subtract `--nb-footer-height` so viewport stacking stays sane.

## Tests

- `uv run pytest`
- `cd frontend && npm run lint && npm test -- --run`

## Linked issues

Closes #84

Linear: https://linear.app/tystar/issue/TYS-192/add-site-footer-eg-created-by-tystar-2026

Made with [Cursor](https://cursor.com)